### PR TITLE
Add public RLP and HTTP API support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         run: cargo rdme --check
 
       - name: Run tests with coverage
-        run: RUST_BACKTRACE=1 cargo tarpaulin --out Xml
+        run: RUST_BACKTRACE=1 cargo tarpaulin --out Xml --all-features
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,12 @@ Possible header types:
 - `Breaking Changes` for any backwards-incompatible changes.
 
 ## [Unreleased]
-<!--
-### Features
-- Added a new struct `MyStruct` with the following methods:
-  - `my_method()`
-  - `other_method()`
--->
 
-## v0.0.1 (2023-10-01)
+### Features
+- Made RLP encoding components public and rewrite it with more conscious syntax.
+
+## v0.0.1-alpha.1 (2023-10-01)
 
 - Initial Release on [crates.io] :tada:
 
-[crates.io]: https://crates.io/crates/thor-devkit.rs
+[crates.io]: https://crates.io/crates/thor-devkit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Possible header types:
 
 ### Features
 - Made RLP encoding components public and rewrite it with more conscious syntax.
+- Added network support for Transaction and Block retrieval.
 
 ## v0.0.1-alpha.1 (2023-10-01)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ itertools = "0.12.0"
 tiny-keccak = { version = "2.0.0", features = ["keccak"] }
 secp256k1 = { version = "0.27.0", features = [ "recovery" ] }
 tiny-bip39 = "1.0.0"
-ethabi = "18.0.0"
 rustc-hex = "2.1.0"
 open-fastrlp = { version = "0.1.4", features = ["std", "ethereum-types"] }
 bytes = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,19 +30,18 @@ tiny-bip39 = "1.0.0"
 rustc-hex = "2.1.0"
 open-fastrlp = { version = "0.1.4", features = ["std", "ethereum-types"] }
 bytes = "1.5.0"
+reqwest = { version = "0.11", features = ["json"], optional = true }
+serde = { version = "^1.0", features=["derive"], optional = true }
+serde-hex = { version = "^0.1", optional = true }
+serde_json = { version = "^1.0", optional = true }
 
 [dev-dependencies]
 # version_sync: to ensure versions in `Cargo.toml` and `README.md` are in sync
 version-sync = "0.9.4"
 rand = { version = "0.8.5", features = ["getrandom"] }
-
-# cargo-bump: to bump package version and tag a commit at the same time.
-# actually, the docs recommend installing this globally:
-#   $ git clone https://github.com/rnag/cargo-bump && cd cargo-bump && cargo install --path . && cd .. && rm -rf cargo-bump
-# logging utilities
-# log = "^0.4"
-# sensible-env-logger = "0.1.0"
-# tokio: for `async` support
-# tokio = { version = "^1.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["full"] }
 
 [features]
+# default = ['http']
+serde = ["dep:serde", "dep:serde-hex", "dep:serde_json"]
+http = ["dep:reqwest", "serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-alloy-rlp = { version = "0.3.3", features = ["derive"] }
 bip32 = { version = "0.5.1", default-features=false, features = [ "alloc", "secp256k1-ffi"] }
 blake2 = "0.10.6"
 ethereum-types = "0.14.0"
@@ -30,6 +29,8 @@ secp256k1 = { version = "0.27.0", features = [ "recovery" ] }
 tiny-bip39 = "1.0.0"
 ethabi = "18.0.0"
 rustc-hex = "2.1.0"
+open-fastrlp = { version = "0.1.4", features = ["std", "ethereum-types"] }
+bytes = "1.5.0"
 
 [dev-dependencies]
 # version_sync: to ensure versions in `Cargo.toml` and `README.md` are in sync

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,14 @@ itertools = "0.12.0"
 tiny-keccak = { version = "2.0.0", features = ["keccak"] }
 secp256k1 = { version = "0.27.0", features = [ "recovery" ] }
 tiny-bip39 = "1.0.0"
-rustc-hex = "2.1.0"
+rustc-hex = "2.1.0"  # TODO: replace with hex
 open-fastrlp = { version = "0.1.4", features = ["std", "ethereum-types"] }
 bytes = "1.5.0"
 reqwest = { version = "0.11", features = ["json"], optional = true }
 serde = { version = "^1.0", features=["derive"], optional = true }
-serde-hex = { version = "^0.1", optional = true }
 serde_json = { version = "^1.0", optional = true }
+serde_with = { version = "^3.4", features = ["hex"], optional = true }
+hex = { version = "^0.4", optional = true }
 
 [dev-dependencies]
 # version_sync: to ensure versions in `Cargo.toml` and `README.md` are in sync
@@ -43,5 +44,5 @@ tokio = { version = "1", features = ["full"] }
 
 [features]
 # default = ['http']
-serde = ["dep:serde", "dep:serde-hex", "dep:serde_json"]
+serde = ["dep:serde", "dep:serde_json", "dep:serde_with", "dep:hex"]
 http = ["dep:reqwest", "serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ bytes = "1.5.0"
 [dev-dependencies]
 # version_sync: to ensure versions in `Cargo.toml` and `README.md` are in sync
 version-sync = "0.9.4"
+rand = { version = "0.8.5", features = ["getrandom"] }
 
 # cargo-bump: to bump package version and tag a commit at the same time.
 # actually, the docs recommend installing this globally:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,6 @@ rand = { version = "0.8.5", features = ["getrandom"] }
 tokio = { version = "1", features = ["full"] }
 
 [features]
-# default = ['http']
+default = ['http']
 serde = ["dep:serde", "dep:serde_json", "dep:serde_with"]
 http = ["dep:reqwest", "serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,14 +27,13 @@ itertools = "0.12.0"
 tiny-keccak = { version = "2.0.0", features = ["keccak"] }
 secp256k1 = { version = "0.27.0", features = [ "recovery" ] }
 tiny-bip39 = "1.0.0"
-rustc-hex = "2.1.0"  # TODO: replace with hex
+rustc-hex = "2.1.0"
 open-fastrlp = { version = "0.1.4", features = ["std", "ethereum-types"] }
 bytes = "1.5.0"
 reqwest = { version = "0.11", features = ["json"], optional = true }
 serde = { version = "^1.0", features=["derive"], optional = true }
 serde_json = { version = "^1.0", optional = true }
 serde_with = { version = "^3.4", features = ["hex"], optional = true }
-hex = { version = "^0.4", optional = true }
 
 [dev-dependencies]
 # version_sync: to ensure versions in `Cargo.toml` and `README.md` are in sync
@@ -44,5 +43,5 @@ tokio = { version = "1", features = ["full"] }
 
 [features]
 # default = ['http']
-serde = ["dep:serde", "dep:serde_json", "dep:serde_with", "dep:hex"]
+serde = ["dep:serde", "dep:serde_json", "dep:serde_with"]
 http = ["dep:reqwest", "serde"]

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ Check out the [Contributing][] section in the docs for more info.
 
 ### License
 
-This project is proudly licensed under the GNU General Public License v3 ([LICENSE](LICENSE)).
+This project is proudly licensed under the Lesser GNU General Public License v3 ([LICENSE](https://github.com/sterliakov/thor-devkit.rs/blob/master/LICENSE)).
 
-`thor-devkit` can be distributed according to the GNU General Public License v3. Contributions
+`thor-devkit` can be distributed according to the Lesser GNU General Public License v3. Contributions
 will be accepted under the same license.
 
 <!-- cargo-rdme end -->

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,7 +1,7 @@
 //! VeChain address operations and verifications.
 
+use crate::rlp::{Decodable, Encodable, RLPError};
 use crate::utils::keccak;
-use alloy_rlp::{Decodable, Encodable};
 use ethereum_types::Address as WrappedAddress;
 pub use secp256k1::{PublicKey, SecretKey as PrivateKey};
 use std::{
@@ -15,8 +15,6 @@ use std::{
 pub struct Address(WrappedAddress);
 
 impl DerefMut for Address {
-    // type Target = WrappedAddress;
-
     fn deref_mut(&mut self) -> &mut WrappedAddress {
         &mut self.0
     }
@@ -29,18 +27,18 @@ impl Deref for Address {
     }
 }
 impl Encodable for Address {
-    fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
-        use crate::transactions::lstrip;
-        alloy_rlp::Bytes::copy_from_slice(&lstrip(self.0)).encode(out)
+    fn encode(&self, out: &mut dyn open_fastrlp::BufMut) {
+        use crate::rlp::lstrip;
+        bytes::Bytes::copy_from_slice(&lstrip(self.0)).encode(out)
     }
 }
 impl Decodable for Address {
-    fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
-        use crate::transactions::static_left_pad;
-        let bytes = alloy_rlp::Bytes::decode(buf)?;
+    fn decode(buf: &mut &[u8]) -> Result<Self, RLPError> {
+        use crate::rlp::static_left_pad;
+        let bytes = bytes::Bytes::decode(buf)?;
         Ok(Self(WrappedAddress::from_slice(
             &static_left_pad::<20>(&bytes).map_err(|e| match e {
-                alloy_rlp::Error::Overflow => alloy_rlp::Error::ListLengthMismatch {
+                RLPError::Overflow => RLPError::ListLengthMismatch {
                     expected: Self::WIDTH,
                     got: bytes.len(),
                 },

--- a/src/address.rs
+++ b/src/address.rs
@@ -6,22 +6,22 @@ use ethereum_types::Address as WrappedAddress;
 pub use secp256k1::{PublicKey, SecretKey as PrivateKey};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "serde")]
-use serde_hex::{SerHex, StrictPfx};
 use std::{
     ops::{Deref, DerefMut},
     result::Result,
     str::FromStr,
 };
 
+#[cfg_attr(feature = "serde", serde_with::serde_as)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(remote = "ethereum_types::H160"))]
-struct _Address(#[cfg_attr(feature = "serde", serde(with = "SerHex::<StrictPfx>"))] [u8; 20]);
+struct _Address(#[cfg_attr(feature = "serde", serde_as(as = "unhex::Hex"))] [u8; 20]);
 
 /// VeChain address.
+#[cfg_attr(feature = "serde", serde_with::serde_as)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct Address(#[cfg_attr(feature = "serde", serde(with = "_Address"))] WrappedAddress);
+pub struct Address(#[cfg_attr(feature = "serde", serde_as(as = "_Address"))] WrappedAddress);
 
 impl DerefMut for Address {
     fn deref_mut(&mut self) -> &mut WrappedAddress {

--- a/src/address.rs
+++ b/src/address.rs
@@ -15,7 +15,7 @@ use std::{
 #[cfg_attr(feature = "serde", serde_with::serde_as)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(remote = "ethereum_types::H160"))]
-struct _Address(#[cfg_attr(feature = "serde", serde_as(as = "unhex::Hex"))] [u8; 20]);
+struct _Address(#[cfg_attr(feature = "serde", serde_as(as = "crate::utils::unhex::Hex"))] [u8; 20]);
 
 /// VeChain address.
 #[cfg_attr(feature = "serde", serde_with::serde_as)]

--- a/src/address.rs
+++ b/src/address.rs
@@ -4,15 +4,24 @@ use crate::rlp::{Decodable, Encodable, RLPError};
 use crate::utils::keccak;
 use ethereum_types::Address as WrappedAddress;
 pub use secp256k1::{PublicKey, SecretKey as PrivateKey};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serde_hex::{SerHex, StrictPfx};
 use std::{
     ops::{Deref, DerefMut},
     result::Result,
     str::FromStr,
 };
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(remote = "ethereum_types::H160"))]
+struct _Address(#[cfg_attr(feature = "serde", serde(with = "SerHex::<StrictPfx>"))] [u8; 20]);
+
 /// VeChain address.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct Address(WrappedAddress);
+pub struct Address(#[cfg_attr(feature = "serde", serde(with = "_Address"))] WrappedAddress);
 
 impl DerefMut for Address {
     fn deref_mut(&mut self) -> &mut WrappedAddress {

--- a/src/address.rs
+++ b/src/address.rs
@@ -100,12 +100,3 @@ impl AddressConvertible for secp256k1::PublicKey {
         Address(WrappedAddress::from_slice(&suffix))
     }
 }
-
-/// Invalid public key format reasons
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum AddressValidationError {
-    /// Not of length 20
-    InvalidLength,
-    /// Not a hex string
-    InvalidHex,
-}

--- a/src/hdnode.rs
+++ b/src/hdnode.rs
@@ -1,6 +1,6 @@
-//! VeChain-tailored Hierarchically deterministic nodes support
+//! VeChain-tailored hierarchically deterministic nodes support
 //!
-//! `Reference <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki>`
+//! [In-deep explanation](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
 
 use bip32::{
     ChainCode, ChildNumber, DerivationPath, ExtendedKey, ExtendedKeyAttrs, ExtendedPrivateKey,

--- a/src/hdnode.rs
+++ b/src/hdnode.rs
@@ -1,6 +1,10 @@
 //! VeChain-tailored hierarchically deterministic nodes support
 //!
 //! [In-deep explanation](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
+//!
+//! This module glues together several important components involved in key derivation
+//! from different sources. You can construct an [`HDNode`] in multiple ways, allowing,
+//! for example, generating a private key from mnemonic or generating a random key.
 
 use bip32::{
     ChainCode, ChildNumber, DerivationPath, ExtendedKey, ExtendedKeyAttrs, ExtendedPrivateKey,
@@ -22,6 +26,9 @@ enum HDNodeVariant {
 use HDNodeVariant::{Full, Restricted};
 
 /// Hierarchically deterministic node.
+///
+/// To construct a wallet, use the [`HDNode::build`] method. It exposes access to the builder
+/// that supports multiple construction methods and validates the arguments.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HDNode(HDNodeVariant);
 
@@ -41,14 +48,14 @@ impl HDNode {
     }
 
     pub fn public_key(&self) -> ExtendedPublicKey<PublicKey> {
-        //! Get underlying public key.
+        //! Get underlying extended public key.
         match &self.0 {
             Full(privkey) => privkey.public_key(),
             Restricted(pubkey) => pubkey.clone(),
         }
     }
     pub fn private_key(&self) -> Result<ExtendedPrivateKey<PrivateKey>, HDNodeError> {
-        //! Get underlying private key.
+        //! Get underlying extended private key.
         match &self.0 {
             Full(privkey) => Ok(privkey.clone()),
             Restricted(_) => Err(HDNodeError::Crypto),
@@ -140,6 +147,36 @@ impl From<bip32::Error> for HDNodeError {
 }
 
 /// Builder for HDNode: use this to construct a node from different sources.
+///
+/// The following sources are supported:
+/// - Binary seed. 64 bytes of raw entropy to use for key generation.
+/// - [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) mnemonic
+///   with optional password. This method is compatible with derivation in Sync2 wallet.
+/// - Master private key bytes and chain code
+/// - Extended private key
+/// - Master public key bytes and chain code
+/// - Extended public key
+///
+/// First two methods accept a derivation path to use (defaults to VeChain path).
+///
+/// For example, here's what you could do:
+///
+/// ```rust
+/// use thor_devkit::hdnode::{Mnemonic, Language, HDNode};
+/// use rand::RngCore;
+/// use rand::rngs::OsRng;
+///
+/// let mnemonic = Mnemonic::from_phrase(
+///     "ignore empty bird silly journey junior ripple have guard waste between tenant",
+///     Language::English,
+/// )
+/// .expect("Should be constructible");
+/// let wallet = HDNode::build().mnemonic(mnemonic).build().expect("Must be buildable");
+/// // OR
+/// let mut entropy = [0u8; 64];
+/// OsRng.fill_bytes(&mut entropy);
+/// let other_wallet = HDNode::build().seed(entropy).build().expect("Must be buildable");
+/// ```
 #[derive(Clone, Default)]
 pub struct HDNodeBuilder<'a> {
     path: Option<DerivationPath>,
@@ -211,7 +248,9 @@ impl<'a> HDNodeBuilder<'a> {
     ) -> Self {
         //! Create an HDNode from private key bytes and chain code.
         //!
+        //! <div class="warning">
         //! Beware that this node cannot be used to derive new private keys.
+        //! </div>
         self.ext_pubkey = Some(ExtendedKey {
             prefix: Prefix::XPUB,
             attrs: ExtendedKeyAttrs {
@@ -227,7 +266,9 @@ impl<'a> HDNodeBuilder<'a> {
     pub fn public_key(mut self, ext_key: ExtendedKey) -> Self {
         //! Create an HDNode from extended public key structure.
         //!
+        //! <div class="warning">
         //! Beware that this node cannot be used to derive new private keys.
+        //! </div>
         self.ext_pubkey = Some(ext_key);
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,13 +77,14 @@
 //!
 //! ## License
 //!
-//! This project is proudly licensed under the GNU General Public License v3 ([LICENSE](LICENSE)).
+//! This project is proudly licensed under the GNU General Public License v3 ([LICENSE](https://github.com/sterliakov/thor-devkit.rs/blob/master/LICENSE)).
 //!
 //! `thor-devkit` can be distributed according to the GNU General Public License v3. Contributions
 //! will be accepted under the same license.
 
 pub mod address;
 pub mod hdnode;
+pub mod rlp;
 pub mod transactions;
 mod utils;
 pub use ethabi;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,6 @@ pub mod hdnode;
 pub mod network;
 pub mod rlp;
 pub mod transactions;
-#[cfg(feature = "http")]
-pub use network::ThorNode;
 mod utils;
 pub use ethereum_types::U256;
 pub use rustc_hex::FromHexError as AddressValidationError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,16 +77,17 @@
 //!
 //! ## License
 //!
-//! This project is proudly licensed under the GNU General Public License v3 ([LICENSE](https://github.com/sterliakov/thor-devkit.rs/blob/master/LICENSE)).
+//! This project is proudly licensed under the Lesser GNU General Public License v3 ([LICENSE](https://github.com/sterliakov/thor-devkit.rs/blob/master/LICENSE)).
 //!
-//! `thor-devkit` can be distributed according to the GNU General Public License v3. Contributions
+//! `thor-devkit` can be distributed according to the Lesser GNU General Public License v3. Contributions
 //! will be accepted under the same license.
 
-pub mod address;
+mod address;
+pub use address::{Address, AddressConvertible, PrivateKey, PublicKey};
 pub mod hdnode;
 pub mod rlp;
 pub mod transactions;
 mod utils;
-pub use ethabi;
 pub use ethereum_types::U256;
-pub use utils::{blake2_256, decode_hex, keccak};
+pub use rustc_hex::FromHexError as AddressValidationError;
+pub use utils::{blake2_256, keccak};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,8 +85,12 @@
 mod address;
 pub use address::{Address, AddressConvertible, PrivateKey, PublicKey};
 pub mod hdnode;
+#[cfg(feature = "http")]
+pub mod network;
 pub mod rlp;
 pub mod transactions;
+#[cfg(feature = "http")]
+pub use network::ThorNode;
 mod utils;
 pub use ethereum_types::U256;
 pub use rustc_hex::FromHexError as AddressValidationError;

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,13 +1,22 @@
 //! Module for interacting with node HTTP APIs.
 
 use crate::rlp::{Bytes, Decodable};
+use crate::transactions::Reserved;
 use crate::utils::unhex;
 use crate::U256;
-use crate::{transactions::Transaction, Address};
+use crate::{
+    transactions::{Clause, Transaction},
+    Address,
+};
 use reqwest::{Client, Url};
 use rustc_hex::ToHex;
 use serde::Deserialize;
-type AResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+/// Generic result of all asynchronous calls in this module.
+pub type AResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+/// 256-byte binary sequence (usually a hash of something)
+pub type Hash256 = [u8; 32];
 
 /// A simple HTTP REST client for a VeChain node.
 pub struct ThorNode {
@@ -24,6 +33,86 @@ struct RawTxResponse {
     meta: Option<TransactionMeta>,
 }
 
+/// Extended transaction data
+#[serde_with::serde_as]
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct ExtendedTransaction {
+    /// Identifier of the transaction
+    #[serde_as(as = "unhex::Hex")]
+    pub id: Hash256,
+    /// The one who signed the transaction
+    pub origin: Address,
+    /// The delegator who paid the gas fee
+    pub delegator: Option<Address>,
+    /// Byte size of the transaction that is RLP encoded
+    pub size: u32,
+    /// Last byte of genesis block ID
+    #[serde(rename = "chainTag")]
+    pub chain_tag: u8,
+    /// 8 bytes prefix of some block ID
+    #[serde(rename = "blockRef")]
+    #[serde_as(as = "unhex::HexNum<8, u64>")]
+    pub block_ref: u64,
+    /// Expiration relative to blockRef, in unit block
+    pub expiration: u32,
+    /// Transaction clauses
+    pub clauses: Vec<Clause>,
+    /// Coefficient used to calculate the final gas price
+    #[serde(rename = "gasPriceCoef")]
+    pub gas_price_coef: u8,
+    /// Max amount of gas can be consumed to execute this transaction
+    pub gas: u64,
+    /// ID of the transaction on which the current transaction depends on. can be null.
+    #[serde(rename = "dependsOn")]
+    #[serde_as(as = "Option<unhex::HexNum<32, U256>>")]
+    pub depends_on: Option<U256>,
+    /// Transaction nonce
+    #[serde_as(as = "unhex::HexNum<8, u64>")]
+    pub nonce: u64,
+}
+
+impl ExtendedTransaction {
+    pub fn as_transaction(self) -> Transaction {
+        //! Convert to package-compatible [`Transaction`]
+        let Self {
+            chain_tag,
+            block_ref,
+            expiration,
+            clauses,
+            gas_price_coef,
+            gas,
+            depends_on,
+            nonce,
+            delegator,
+            ..
+        } = self;
+        Transaction {
+            chain_tag,
+            block_ref,
+            expiration,
+            clauses,
+            gas_price_coef,
+            gas,
+            depends_on,
+            nonce,
+            reserved: if delegator.is_some() {
+                Some(Reserved::new_delegated())
+            } else {
+                None
+            },
+            signature: None,
+        }
+    }
+}
+
+#[serde_with::serde_as]
+#[derive(Deserialize)]
+struct ExtendedTransactionResponse {
+    #[serde(flatten)]
+    transaction: ExtendedTransaction,
+    meta: Option<TransactionMeta>,
+}
+
 /// Transaction metadata
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
@@ -31,13 +120,13 @@ pub struct TransactionMeta {
     /// Block identifier
     #[serde(rename = "blockID")]
     #[serde_as(as = "unhex::Hex")]
-    pub block_id: [u8; 32],
+    pub block_id: Hash256,
     /// Block number (height)
     #[serde(rename = "blockNumber")]
-    pub block_number: i32,
+    pub block_number: u32,
     /// Block unix timestamp
     #[serde(rename = "blockTimestamp")]
-    pub block_timestamp: i32,
+    pub block_timestamp: u32,
 }
 
 /// Transaction receipt
@@ -45,25 +134,25 @@ pub struct TransactionMeta {
 pub struct Receipt {
     /// Amount of gas consumed by this transaction
     #[serde(rename = "gasUsed")]
-    pub gas_used: i32,
+    pub gas_used: u32,
     /// Address of account who paid used gas
     #[serde(rename = "gasPayer")]
     pub gas_payer: Address,
     /// Hex form of amount of paid energy
-    #[serde(rename = "paid")]
     pub paid: U256,
     /// Hex form of amount of reward
-    #[serde(rename = "reward")]
     pub reward: U256,
     /// true means the transaction was reverted
-    #[serde(rename = "reverted")]
     pub reverted: bool,
     /// Outputs (if this transaction was a contract call)
-    #[serde(rename = "outputs")]
     pub outputs: Vec<ReceiptOutput>,
-    /// Receipt metadata
-    #[serde(rename = "meta")]
-    pub meta: ReceiptMeta,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+struct ReceiptResponse {
+    #[serde(flatten)]
+    body: Receipt,
+    meta: ReceiptMeta,
 }
 
 /// Single output in the transaction receipt
@@ -73,10 +162,8 @@ pub struct ReceiptOutput {
     #[serde(rename = "contractAddress")]
     pub contract_address: Option<Address>,
     /// Emitted contract events
-    #[serde(rename = "events")]
     pub events: Vec<Event>,
     /// Transfers executed during the contract call
-    #[serde(rename = "transfers")]
     pub transfers: Vec<Transfer>,
 }
 
@@ -84,20 +171,20 @@ pub struct ReceiptOutput {
 #[serde_with::serde_as]
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 pub struct ReceiptMeta {
-    /// Block identifier (bytes32)
+    /// Block identifier
     #[serde(rename = "blockID")]
     #[serde_as(as = "unhex::Hex")]
-    pub block_id: [u8; 32],
+    pub block_id: Hash256,
     /// Block number (height)
     #[serde(rename = "blockNumber")]
-    pub block_number: i32,
+    pub block_number: u32,
     /// Block unix timestamp
     #[serde(rename = "blockTimestamp")]
-    pub block_timestamp: i32,
+    pub block_timestamp: u32,
     /// Transaction identifier
     #[serde(rename = "txID")]
     #[serde_as(as = "unhex::Hex")]
-    pub tx_id: [u8; 32],
+    pub tx_id: Hash256,
     /// Transaction origin (signer)
     #[serde(rename = "txOrigin")]
     pub tx_origin: Address,
@@ -108,14 +195,11 @@ pub struct ReceiptMeta {
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 pub struct Event {
     /// The address of contract which produces the event
-    #[serde(rename = "address")]
     pub address: Address,
     /// Event topics
-    #[serde(rename = "topics")]
     #[serde_as(as = "Vec<unhex::Hex>")]
-    pub topics: Vec<[u8; 32]>,
+    pub topics: Vec<Hash256>,
     /// Event data
-    #[serde(rename = "data")]
     #[serde_as(as = "unhex::Hex")]
     pub data: Bytes,
 }
@@ -124,14 +208,123 @@ pub struct Event {
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 pub struct Transfer {
     /// Address that sends tokens
-    #[serde(rename = "sender")]
     pub sender: Address,
     /// Address that receives tokens
-    #[serde(rename = "recipient")]
     pub recipient: Address,
     /// Amount of tokens
-    #[serde(rename = "amount")]
     pub amount: U256,
+}
+
+/// A blockchain block.
+#[serde_with::serde_as]
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct BlockInfo {
+    /// Block number (height)
+    pub number: u32,
+    /// Block identifier
+    #[serde_as(as = "unhex::Hex")]
+    pub id: Hash256,
+    /// RLP encoded block size in bytes
+    pub size: u32,
+    /// Parent block ID
+    #[serde_as(as = "unhex::Hex")]
+    #[serde(rename = "parentID")]
+    pub parent_id: Hash256,
+    /// Block unix timestamp
+    pub timestamp: u32,
+    /// Block gas limit (max allowed accumulative gas usage of transactions)
+    #[serde(rename = "gasLimit")]
+    pub gas_limit: u32,
+    /// Address of account to receive block reward
+    pub beneficiary: Address,
+    /// Accumulative gas usage of transactions
+    #[serde(rename = "gasUsed")]
+    pub gas_used: u32,
+    /// Sum of all ancestral blocks' score
+    #[serde(rename = "totalScore")]
+    pub total_score: u32,
+    /// Root hash of transactions in the block
+    #[serde_as(as = "unhex::Hex")]
+    #[serde(rename = "txsRoot")]
+    pub txs_root: Hash256,
+    /// Supported txs features bitset
+    #[serde(rename = "txsFeatures")]
+    pub txs_features: u32,
+    /// Root hash of accounts state
+    #[serde_as(as = "unhex::Hex")]
+    #[serde(rename = "stateRoot")]
+    pub state_root: Hash256,
+    /// Root hash of transaction receipts
+    #[serde_as(as = "unhex::Hex")]
+    #[serde(rename = "receiptsRoot")]
+    pub receipts_root: Hash256,
+    /// Is in trunk?
+    #[serde(rename = "isTrunk")]
+    pub is_trunk: bool,
+    /// Is finalized?
+    #[serde(rename = "isFinalized")]
+    pub is_finalized: bool,
+    /// Whether the block signer voted COM(Commit) in BFT
+    pub com: bool,
+    /// The one who signed this block
+    pub signer: Address,
+}
+
+/// Transaction data included in the block extended details.
+///
+/// Combines [`ExtendedTransaction`] and [`Receipt`].
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct BlockTransaction {
+    /// Transaction details
+    #[serde(flatten)]
+    pub transaction: ExtendedTransaction,
+    /// Transaction receipt
+    #[serde(flatten)]
+    pub receipt: Receipt,
+}
+
+#[serde_with::serde_as]
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+struct BlockResponse {
+    #[serde(flatten)]
+    base: BlockInfo,
+    #[serde_as(as = "Vec<unhex::Hex>")]
+    transactions: Vec<Hash256>,
+}
+
+#[serde_with::serde_as]
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+struct BlockExtendedResponse {
+    #[serde(flatten)]
+    base: BlockInfo,
+    transactions: Vec<BlockTransaction>,
+}
+
+/// Block reference: a way to identify the block on the chain.
+#[derive(Clone, Debug)]
+pub enum BlockReference {
+    /// Latest: already approved by some node, but not finalized yet.
+    Best,
+    /// Finalized: block is frozen on chain.
+    Finalized,
+    /// Block ordinal number (1..)
+    Number(u64),
+    /// Block ID
+    ID(Hash256),
+}
+
+impl BlockReference {
+    fn as_query_param(&self) -> String {
+        match self {
+            BlockReference::Best => "best".to_string(),
+            BlockReference::Finalized => "finalized".to_string(),
+            BlockReference::Number(num) => format!("0x{:02x}", num),
+            BlockReference::ID(id) => {
+                let hex: String = id.to_hex();
+                format!("0x{}", hex)
+            }
+        }
+    }
 }
 
 impl ThorNode {
@@ -162,7 +355,7 @@ impl ThorNode {
 
     pub async fn fetch_transaction(
         &self,
-        transaction_id: [u8; 32],
+        transaction_id: Hash256,
     ) -> AResult<Option<(Transaction, Option<TransactionMeta>)>> {
         //! Retrieve a [`Transaction`] from node by its ID.
         //!
@@ -170,6 +363,10 @@ impl ThorNode {
         //!
         //! Meta can be [`None`] if a transaction was broadcasted, but
         //! not yet included into a block.
+        //!
+        //! This method exists for interoperability with [`Transaction`]
+        //! from other parts of library. You can get more info from node
+        //! with [`ThorNode::fetch_extended_transaction`].
         let client = Client::new();
         let hex_id: String = transaction_id.to_hex();
         let path = format!("/transactions/0x{}", hex_id);
@@ -189,11 +386,41 @@ impl ThorNode {
         }
     }
 
+    pub async fn fetch_extended_transaction(
+        &self,
+        transaction_id: Hash256,
+    ) -> AResult<Option<(ExtendedTransaction, Option<TransactionMeta>)>> {
+        //! Retrieve a [`Transaction`] from node by its ID.
+        //!
+        //! Returns [`None`] for nonexistent transactions.
+        //!
+        //! Meta can be [`None`] if a transaction was broadcasted, but
+        //! not yet included into a block.
+        //!
+        //! This method returns more data than [`ThorNode::fetch_transaction`],
+        //! but is not interoperable with [`Transaction`].
+        let client = Client::new();
+        let hex_id: String = transaction_id.to_hex();
+        let path = format!("/transactions/0x{}", hex_id);
+        let response = client
+            .get(self.base_url.join(&path)?)
+            .send()
+            .await?
+            .text()
+            .await?;
+        if response.strip_suffix('\n').unwrap_or(&response) == "null" {
+            Ok(None)
+        } else {
+            let decoded: ExtendedTransactionResponse = serde_json::from_str(&response)?;
+            Ok(Some((decoded.transaction, decoded.meta)))
+        }
+    }
+
     pub async fn fetch_transaction_receipt(
         &self,
-        transaction_id: [u8; 32],
-    ) -> AResult<Option<Receipt>> {
-        //! Retrieve a [`Transaction`] from node by its ID.
+        transaction_id: Hash256,
+    ) -> AResult<Option<(Receipt, ReceiptMeta)>> {
+        //! Retrieve a transaction receipt from node given a transaction ID.
         //!
         //! Returns [`None`] for nonexistent or not mined transactions.
         let client = Client::new();
@@ -208,8 +435,56 @@ impl ThorNode {
         if response.strip_suffix('\n').unwrap_or(&response) == "null" {
             Ok(None)
         } else {
-            let decoded: Receipt = serde_json::from_str(&response)?;
-            Ok(Some(decoded))
+            let decoded: ReceiptResponse = serde_json::from_str(&response)?;
+            Ok(Some((decoded.body, decoded.meta)))
+        }
+    }
+
+    pub async fn fetch_block(
+        &self,
+        block_ref: BlockReference,
+    ) -> AResult<Option<(BlockInfo, Vec<Hash256>)>> {
+        //! Retrieve a block from node by given identifier.
+        //!
+        //! Returns [`None`] for nonexistent blocks.
+        let client = Client::new();
+        let path = format!("/blocks/{}", block_ref.as_query_param());
+        let response = client
+            .get(self.base_url.join(&path)?)
+            .send()
+            .await?
+            .text()
+            .await?;
+        if response.strip_suffix('\n').unwrap_or(&response) == "null" {
+            Ok(None)
+        } else {
+            let decoded: BlockResponse = serde_json::from_str(&response)?;
+            Ok(Some((decoded.base, decoded.transactions)))
+        }
+    }
+
+    pub async fn fetch_block_expanded(
+        &self,
+        block_ref: BlockReference,
+    ) -> AResult<Option<(BlockInfo, Vec<BlockTransaction>)>> {
+        //! Retrieve a block from node by given identifier together with extended
+        //! transaction details.
+        //!
+        //! Returns [`None`] for nonexistent blocks.
+        let client = Client::new();
+        let path = format!("/blocks/{}", block_ref.as_query_param());
+        let response = client
+            .get(self.base_url.join(&path)?)
+            .query(&[("expanded", "true")])
+            .send()
+            .await?
+            .text()
+            .await?;
+        if response.strip_suffix('\n').unwrap_or(&response) == "null" {
+            Ok(None)
+        } else {
+            let decoded: BlockExtendedResponse = serde_json::from_str(&response)?;
+            Ok(Some((decoded.base, decoded.transactions)))
         }
     }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,0 +1,227 @@
+//! Module for interacting with node HTTP APIs.
+
+use crate::rlp::{Bytes, Decodable};
+use crate::U256;
+use crate::{transactions::Transaction, Address};
+use reqwest::{Client, Url};
+use rustc_hex::ToHex;
+use serde::Deserialize;
+use serde_hex::{SerHex, SerHexSeq, StrictPfx};
+type AResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+/// A simple HTTP REST client for a VeChain node.
+pub struct ThorNode {
+    base_url: Url,
+    #[allow(dead_code)]
+    chain_tag: u8,
+}
+
+#[derive(Deserialize)]
+struct RawTxResponse {
+    #[serde(rename = "raw")]
+    #[serde(with = "SerHexSeq::<StrictPfx>")]
+    raw: Bytes,
+    #[serde(rename = "meta")]
+    meta: Option<TransactionMeta>,
+}
+
+/// Transaction metadata
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
+pub struct TransactionMeta {
+    /// Block identifier
+    #[serde(rename = "blockID")]
+    #[serde(with = "SerHex::<StrictPfx>")]
+    pub block_id: [u8; 32],
+    /// Block number (height)
+    #[serde(rename = "blockNumber")]
+    pub block_number: i32,
+    /// Block unix timestamp
+    #[serde(rename = "blockTimestamp")]
+    pub block_timestamp: i32,
+}
+
+/// Transaction receipt
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct Receipt {
+    /// Amount of gas consumed by this transaction
+    #[serde(rename = "gasUsed")]
+    pub gas_used: i32,
+    /// Address of account who paid used gas
+    #[serde(rename = "gasPayer")]
+    pub gas_payer: Address,
+    /// Hex form of amount of paid energy
+    #[serde(rename = "paid")]
+    pub paid: U256,
+    /// Hex form of amount of reward
+    #[serde(rename = "reward")]
+    pub reward: U256,
+    /// true means the transaction was reverted
+    #[serde(rename = "reverted")]
+    pub reverted: bool,
+    /// Outputs (if this transaction was a contract call)
+    #[serde(rename = "outputs")]
+    pub outputs: Vec<ReceiptOutput>,
+    /// Receipt metadata
+    #[serde(rename = "meta")]
+    pub meta: ReceiptMeta,
+}
+
+/// Single output in the transaction receipt
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct ReceiptOutput {
+    /// Deployed contract address, if the corresponding clause is a contract deployment clause
+    #[serde(rename = "contractAddress")]
+    pub contract_address: Option<Address>,
+    /// Emitted contract events
+    #[serde(rename = "events")]
+    pub events: Vec<Event>,
+    /// Transfers executed during the contract call
+    #[serde(rename = "transfers")]
+    pub transfers: Vec<Transfer>,
+}
+
+/// Transaction receipt metadata
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct ReceiptMeta {
+    /// Block identifier (bytes32)
+    #[serde(rename = "blockID")]
+    #[serde(with = "SerHex::<StrictPfx>")]
+    pub block_id: [u8; 32],
+    /// Block number (height)
+    #[serde(rename = "blockNumber")]
+    pub block_number: i32,
+    /// Block unix timestamp
+    #[serde(rename = "blockTimestamp")]
+    pub block_timestamp: i32,
+    /// Transaction identifier
+    #[serde(rename = "txID")]
+    #[serde(with = "SerHex::<StrictPfx>")]
+    pub tx_id: [u8; 32],
+    /// Transaction origin (signer)
+    #[serde(rename = "txOrigin")]
+    pub tx_origin: Address,
+}
+
+/// Emitted contract event
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct Event {
+    /// The address of contract which produces the event
+    #[serde(rename = "address")]
+    pub address: Address,
+    /// Event topics
+    #[serde(rename = "topics")]
+    pub topics: Vec<Topic>,
+    /// Event data
+    #[serde(rename = "data")]
+    #[serde(with = "SerHexSeq::<StrictPfx>")]
+    pub data: Bytes,
+}
+
+/// Single event topic.
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct Topic(#[serde(with = "SerHex::<StrictPfx>")] pub [u8; 32]);
+
+/// Single transfer during the contract call
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct Transfer {
+    /// Address that sends tokens
+    #[serde(rename = "sender")]
+    pub sender: Address,
+    /// Address that receives tokens
+    #[serde(rename = "recipient")]
+    pub recipient: Address,
+    /// Amount of tokens
+    #[serde(rename = "amount")]
+    pub amount: U256,
+}
+
+impl ThorNode {
+    /// Chain tag for mainnet
+    pub const MAINNET_CHAIN_TAG: u8 = 0x4A;
+    /// REST API URL for mainnet (one possible)
+    pub const MAINNET_BASE_URL: &'static str = "https://mainnet.vecha.in/";
+    /// Chain tag for testnet
+    pub const TESTNET_CHAIN_TAG: u8 = 0x27;
+    /// REST API URL for testnet (one possible)
+    pub const TESTNET_BASE_URL: &'static str = "https://testnet.vecha.in/";
+
+    pub fn mainnet() -> Self {
+        //! Mainnet parameters
+        Self {
+            base_url: Self::MAINNET_BASE_URL.parse().unwrap(),
+            chain_tag: Self::MAINNET_CHAIN_TAG,
+        }
+    }
+
+    pub fn testnet() -> Self {
+        //! Testnet parameters
+        Self {
+            base_url: Self::TESTNET_BASE_URL.parse().unwrap(),
+            chain_tag: Self::TESTNET_CHAIN_TAG,
+        }
+    }
+
+    pub async fn fetch_transaction(
+        &self,
+        transaction_id: [u8; 32],
+    ) -> AResult<Option<(Transaction, Option<TransactionMeta>)>> {
+        //! Retrieve a [`Transaction`] from node by its ID.
+        //!
+        //! Returns [`None`] for nonexistent transactions.
+        //!
+        //! Meta can be [`None`] if a transaction was broadcasted, but
+        //! not yet included into a block.
+        let client = Client::new();
+        let hex_id: String = transaction_id.to_hex();
+        let path = format!("/transactions/0x{}", hex_id);
+        let response = client
+            .get(self.base_url.join(&path)?)
+            .query(&[("raw", "true")])
+            .send()
+            .await?
+            .text()
+            .await?;
+        if response.strip_suffix("\n").unwrap_or(&response) == "null" {
+            Ok(None)
+        } else {
+            let decoded: RawTxResponse = serde_json::from_str(&response)?;
+            let tx = Transaction::decode(&mut &decoded.raw[..])?;
+            Ok(Some((tx, decoded.meta)))
+        }
+    }
+
+    pub async fn fetch_transaction_receipt(
+        &self,
+        transaction_id: [u8; 32],
+    ) -> AResult<Option<Receipt>> {
+        //! Retrieve a [`Transaction`] from node by its ID.
+        //!
+        //! Returns [`None`] for nonexistent or not mined transactions.
+        let client = Client::new();
+        let hex_id: String = transaction_id.to_hex();
+        let path = format!("/transactions/0x{}/receipt", hex_id);
+        let response = client
+            .get(self.base_url.join(&path)?)
+            .send()
+            .await?
+            .text()
+            .await?;
+        if response.strip_suffix("\n").unwrap_or(&response) == "null" {
+            Ok(None)
+        } else {
+            let decoded: Receipt = serde_json::from_str(&response)?;
+            Ok(Some(decoded))
+        }
+    }
+
+    pub async fn broadcast_transaction(&self, transaction: &Transaction) -> AResult<()> {
+        //! Broadcast a new [`Transaction`] to the node.
+        let client = Client::new();
+        client
+            .post(self.base_url.join("/transactions/")?)
+            .body(transaction.to_broadcastable_bytes()?)
+            .send()
+            .await?;
+        Ok(())
+    }
+}

--- a/src/rlp.rs
+++ b/src/rlp.rs
@@ -1,0 +1,436 @@
+//! This module enables RLP encoding of high-level objects.
+//!
+//! RLP (recursive length prefix) is a common algorithm for encoding
+//! of variable length binary data. RLP encodes data before storing on disk
+//! or transmitting via network.
+//!
+//! Theory
+//! ------
+//!
+//! Encoding
+//! ********
+//!
+//! Primary RLP can only deal with "item" type, which is defined as:
+//!
+//! - Byte string ([`Bytes`]) or
+//! - Sequence of items ([`Vec`], fixed array or slice).
+//!
+//! Some examples are:
+//!
+//! * ``b'\x00\xff'``
+//! * empty list ``vec![]``
+//! * list of bytes ``vec![vec![0u8], vec![1u8, 3u8]]``
+//! * list of combinations ``vec![vec![], vec![0u8], vec![vec![0]]]``
+//!
+//! The encoded result is always a byte string (sequence of [`u8`]).
+//!
+//! Encoding algorithm
+//! ******************
+//!
+//! Given `x` item as input, we define `rlp_encode` as the following algorithm:
+//!
+//! Let `concat` be a function that joins given bytes into single byte sequence.
+//! 1. If `x` is a single byte and `0x00 <= x <= 0x7F`, `rlp_encode(x) = x`.
+//! 1. Otherwise, if `x` is a byte string, let `len(x)` be length of `x` in bytes
+//!    and define encoding as follows:
+//!    * If `0 < len(x) < 0x38` (note that empty byte string fulfills this requirement), then
+//!      ```txt
+//!      rlp_encode(x) = concat(0x80 + len(x), x)
+//!      ```
+//!      In this case first byte is in range `[0x80; 0xB7]`.
+//!    * If `0x38 <= len(x) <= 0xFFFFFFFF`, then
+//!      ```txt
+//!      rlp_encode(x) = concat(0xB7 + len(len(x)), len(x), x)
+//!      ```
+//!      In this case first byte is in range `[0xB8; 0xBF]`.
+//!    * For longer strings encoding is undefined.
+//! 1. Otherwise, if `x` is a list, let `s = concat(map(rlp_encode, x))`
+//!    be concatenation of RLP encodings of all its items.
+//!    * If `0 < len(s) < 0x38` (note that empty list matches), then
+//!      ```txt
+//!      rlp_encode(x) = concat(0xC0 + len(s), s)
+//!      ```
+//!      In this case first byte is in range `[0xC0; 0xF7]`.
+//!    * If `0x38 <= len(s) <= 0xFFFFFFFF`, then
+//!      ```txt
+//!      rlp_encode(x) = concat(0xF7 + len(len(s)), len(s), x)
+//!      ```
+//!      In this case first byte is in range `[0xF8; 0xFF]`.
+//!    * For longer lists encoding is undefined.
+//!
+//! See more in [Ethereum wiki](https://eth.wiki/fundamentals/rlp).
+//!
+//! Encoding examples
+//! *****************
+//!
+//! | ``x``             |       ``rlp_encode(x)``        |
+//! |-------------------|--------------------------------|
+//! | ``b''``           | ``0x80``                       |
+//! | ``b'\x00'``       | ``0x00``                       |
+//! | ``b'\x0F'``       | ``0x0F``                       |
+//! | ``b'\x79'``       | ``0x79``                       |
+//! | ``b'\x80'``       | ``0x81 0x80``                  |
+//! | ``b'\xFF'``       | ``0x81 0xFF``                  |
+//! | ``b'foo'``        | ``0x83 0x66 0x6F 0x6F``        |
+//! | ``[]``            | ``0xC0``                       |
+//! | ``[b'\x0F']``     | ``0xC1 0x0F``                  |
+//! | ``[b'\xEF']``     | ``0xC1 0x81 0xEF``             |
+//! | ``[[], [[]]]``    | ``0xC3 0xC0 0xC1 0xC0``        |
+//!
+//!
+//! Serialization
+//! *************
+//!
+//! However, in the real world, the inputs are not pure bytes nor lists.
+//! We need a way to encode numbers (like [`u64`]), custom structs, enums and other
+//! more complex machinery that exists in the surrounding code.
+//!
+//! This library wraps [`open_fastrlp`](https://docs.rs/open-fastrlp/0.1.4/open_fastrlp/)
+//! crate, so everything mentioned there about [`Encodable`] and [`Decodable`] traits still
+//! applies. You can implement those for any object to make it RLP-serializable.
+//!
+//! However, following this approach directly results in cluttered code: your `struct`s
+//! now have to use field types that match serialization, which may be very inconvenient.
+//!
+//! To avoid this pitfall, this RLP implementation allows "extended" struct definition
+//! via a macro. Let's have a look at `Transaction` definition:
+//!
+//! ```rust
+//! use thor_devkit::rlp::{AsBytes, AsVec, Maybe, Bytes};
+//! use thor_devkit::{rlp_encodable, U256};
+//! use thor_devkit::transactions::{Clause, Reserved};
+//!
+//! rlp_encodable! {
+//!     /// Represents a single VeChain transaction.
+//!     #[derive(Clone, Debug, Eq, PartialEq)]
+//!     pub struct Transaction {
+//!         /// Chain tag
+//!         pub chain_tag: u8,
+//!         pub block_ref: u64,
+//!         pub expiration: u32,
+//!         pub clauses: Vec<Clause>,
+//!         pub gas_price_coef: u8,
+//!         pub gas: u64,
+//!         pub depends_on: Option<U256> => AsBytes<U256>,
+//!         pub nonce: u64,
+//!         pub reserved: Option<Reserved> => AsVec<Reserved>,
+//!         pub signature: Option<Bytes> => Maybe<Bytes>,
+//!     }
+//! }
+//! ```
+//!
+//! What's going on here? First, some fields are encoded "as usual": unsigned integers
+//! are encoded just fine and you likely won't need any different encoding. However,
+//! some fields work in a different way. `depends_on` is a number that may be present
+//! or absent, and it should be encoded as a byte sting. `U256` is already encoded this
+//! way, but `None` is not ([`Option`] is not RLP-serializable on itself). So we wrap it
+//! in a special wrapper: [`AsBytes`]. [`AsBytes<T>`] will serialize `Some(T)` as `T` and
+//! [`None`] as an empty byte string.
+//!
+//! `reserved` is a truly special struct that has custom encoding implemented for it.
+//! That implementation serializes `Reserved` into a [`Vec<Bytes>`], and then serializes
+//! this [`Vec<Bytes>`] to the output stream. If it is empty, an empty vector should be
+//! written instead. This is achieved via [`AsVec`] annotation.
+//!
+//! [`Maybe`] is a third special wrapper. Fields annotated with [`Maybe`] may only be placed
+//! last (otherwise encoding is ambiguous), and with [`Maybe<T>`] `Some(T)` is serialized
+//! as `T` and [`None`] --- as nothing (zero bytes added).
+//!
+//! Fields comments are omitted here for brevity, they are preserved as well.
+//!
+//! This macro adds both decoding and encoding capabilities. See examples folder
+//! for more examples of usage, including custom types and machinery.
+//!
+//! Note that this syntax is not restricted to these three wrappers, you can use
+//! any types with proper [`From`] implementation:
+//!
+//! ```rust
+//! use thor_devkit::rlp_encodable;
+//!
+//! #[derive(Clone)]
+//! struct MySeries {
+//!     left: [u8; 2],
+//!     right: [u8; 2],
+//! }
+//!
+//! impl From<MySeries> for u32 {
+//!     fn from(value: MySeries) -> Self {
+//!         Self::from_be_bytes(value.left.into_iter().chain(value.right).collect::<Vec<_>>().try_into().unwrap())
+//!     }
+//! }
+//! impl From<u32> for MySeries {
+//!     fn from(value: u32) -> Self {
+//!         let [a, b, c, d] = value.to_be_bytes();
+//!         Self{ left: [a, b], right: [c, d] }
+//!     }
+//! }
+//!
+//! rlp_encodable! {
+//!     pub struct Foo {
+//!         pub foo: MySeries => u32,
+//!     }
+//! }
+//! ```
+//!
+
+pub use bytes::{Buf, BufMut, Bytes, BytesMut};
+pub use open_fastrlp::{Decodable, DecodeError as RLPError, Encodable, Header};
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __encode_as {
+    ($out:expr, $field:expr) => {{
+        use $crate::rlp::Encodable;
+        $field.encode($out)
+    }};
+    ($out:expr, $field:expr => $cast:ty) => {{
+        use $crate::rlp::Encodable;
+        // TODO: this clone bugs me, we should be able to do better
+        <$cast>::from($field.clone()).encode($out)
+    }};
+
+    ($out:expr, $field:expr $(=> $cast:ty)?, $($fields:expr $(=> $casts:ty)?),+) => {{
+        $crate::__encode_as! { $out, $field $(=> $cast)? }
+        $crate::__encode_as! { $out, $($fields $(=> $casts)?),+ }
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __decode_as {
+    ($buf:expr, $field:ty) => {{
+        #[allow(unused_imports)]
+        use $crate::rlp::Decodable;
+        <$field>::decode($buf)?
+    }};
+    ($buf:expr, $field:ty => $cast:ty) => {{
+        #[allow(unused_imports)]
+        use $crate::rlp::Decodable;
+        <$field>::from(<$cast>::decode($buf)?)
+    }};
+
+    ($buf:expr, $field:ty $(=> $cast:ty)?, $($fields:ty $(=> $casts:ty)?),+) => {{
+        $crate::__decode_as! { $buf, $field $(=> $cast)? }
+        $crate::__decode_as! { $buf, $($fields $(=> $casts)?),+ }
+    }};
+}
+
+/// Create an RLP-encodable struct by specifying types to cast to.
+#[macro_export]
+macro_rules! rlp_encodable {
+    (
+        $(#[$attr:meta])*
+        $vis:vis struct $name:ident {
+            $(
+                $(#[$field_attr:meta])*
+                $field_vis:vis $field_name:ident: $field_type:ty $(=> $cast:ty)?,
+            )*
+        }
+    ) => {
+        $(#[$attr])*
+        $vis struct $name {
+            $(
+                $(#[$field_attr])*
+                $field_vis $field_name: $field_type,
+            )*
+        }
+
+        impl $name {
+            fn encode_internal(&self, out: &mut dyn $crate::rlp::BufMut) {
+                $crate::__encode_as!(out, $(self.$field_name $(=> $cast)?),+)
+            }
+        }
+
+        impl $crate::rlp::Encodable for $name {
+            fn encode(&self, out: &mut dyn $crate::rlp::BufMut) {
+                let mut buf = $crate::rlp::BytesMut::new();
+                self.encode_internal(&mut buf);
+                $crate::rlp::Header {
+                    list: true,
+                    payload_length: buf.len()
+                }.encode(out);
+                out.put_slice(&buf)
+            }
+        }
+
+        impl $crate::rlp::Decodable for $name {
+            fn decode(buf: &mut &[u8]) -> Result<Self, $crate::rlp::RLPError> {
+                $crate::rlp::Header::decode(buf)?;
+                Ok(Self {
+                    $($field_name: $crate::__decode_as!(buf, $field_type $(=> $cast)? )),*
+                })
+            }
+        }
+    }
+}
+
+/// Serialization wrapper for `Option` to serialize `None` as empty `Bytes`.
+///
+/// <div class="warning">
+///  Do not use it directly: it is only intended for use with `rlp_encodable!` macro.
+/// </div>
+pub enum AsBytes<T: Encodable + Decodable> {
+    #[doc(hidden)]
+    Just(T),
+    #[doc(hidden)]
+    Nothing,
+}
+impl<T: Encodable + Decodable> Encodable for AsBytes<T> {
+    fn encode(&self, out: &mut dyn BufMut) {
+        match self {
+            Self::Just(value) => value.encode(out),
+            Self::Nothing => Bytes::new().encode(out),
+        }
+    }
+}
+impl<T: Encodable + Decodable, S: Into<T>> From<Option<S>> for AsBytes<T> {
+    fn from(value: Option<S>) -> Self {
+        match value {
+            Some(v) => Self::Just(v.into()),
+            None => Self::Nothing,
+        }
+    }
+}
+impl<T: Encodable + Decodable> From<AsBytes<T>> for Option<T> {
+    fn from(value: AsBytes<T>) -> Self {
+        match value {
+            AsBytes::Just(v) => Self::Some(v),
+            AsBytes::Nothing => Self::None,
+        }
+    }
+}
+impl<T: Encodable + Decodable> Decodable for AsBytes<T> {
+    fn decode(buf: &mut &[u8]) -> Result<Self, open_fastrlp::DecodeError> {
+        if buf[0] == open_fastrlp::EMPTY_STRING_CODE {
+            Bytes::decode(buf)?;
+            Ok(Self::Nothing)
+        } else {
+            Ok(Self::Just(T::decode(buf)?))
+        }
+    }
+}
+
+/// Serialization wrapper for `Option` to serialize `None` as empty `Vec`.
+///
+/// <div class="warning">
+///  Do not use it directly: it is only intended for use with `rlp_encodable!` macro.
+/// </div>
+pub enum AsVec<T: Encodable + Decodable> {
+    #[doc(hidden)]
+    Just(T),
+    #[doc(hidden)]
+    Nothing,
+}
+impl<T: Encodable + Decodable> Encodable for AsVec<T> {
+    fn encode(&self, out: &mut dyn BufMut) {
+        match self {
+            Self::Just(value) => value.encode(out),
+            Self::Nothing => Vec::<u8>::new().encode(out),
+        }
+    }
+}
+impl<T: Encodable + Decodable, S: Into<T>> From<Option<S>> for AsVec<T> {
+    fn from(value: Option<S>) -> Self {
+        match value {
+            Some(v) => Self::Just(v.into()),
+            None => Self::Nothing,
+        }
+    }
+}
+impl<T: Encodable + Decodable> From<AsVec<T>> for Option<T> {
+    fn from(value: AsVec<T>) -> Self {
+        match value {
+            AsVec::Just(v) => Self::Some(v),
+            AsVec::Nothing => Self::None,
+        }
+    }
+}
+impl<T: Encodable + Decodable> Decodable for AsVec<T> {
+    fn decode(buf: &mut &[u8]) -> Result<Self, open_fastrlp::DecodeError> {
+        if buf[0] == open_fastrlp::EMPTY_LIST_CODE {
+            Vec::<u8>::decode(buf)?;
+            Ok(Self::Nothing)
+        } else {
+            Ok(Self::Just(T::decode(buf)?))
+        }
+    }
+}
+
+/// Serialization wrapper for `Option` to serialize `None` as nothing (do not modify
+/// output stream).
+///
+/// <div class="warning">
+///  Do not use it directly: it is only intended for use with `rlp_encodable!` macro.
+/// </div>
+pub enum Maybe<T: Encodable + Decodable> {
+    #[doc(hidden)]
+    Just(T),
+    #[doc(hidden)]
+    Nothing,
+}
+impl<T: Encodable + Decodable> Encodable for Maybe<T> {
+    fn encode(&self, out: &mut dyn BufMut) {
+        match self {
+            Self::Just(value) => value.encode(out),
+            Self::Nothing => (),
+        }
+    }
+}
+impl<T: Encodable + Decodable> Decodable for Maybe<T> {
+    fn decode(buf: &mut &[u8]) -> Result<Self, open_fastrlp::DecodeError> {
+        if buf.remaining() == 0 {
+            Ok(Self::Nothing)
+        } else {
+            Ok(Self::Just(T::decode(buf)?))
+        }
+    }
+}
+impl<T: Encodable + Decodable, S: Into<T>> From<Option<S>> for Maybe<T> {
+    fn from(value: Option<S>) -> Self {
+        match value {
+            Some(v) => Self::Just(v.into()),
+            None => Self::Nothing,
+        }
+    }
+}
+impl<T: Encodable + Decodable> From<Maybe<T>> for Option<T> {
+    fn from(value: Maybe<T>) -> Self {
+        match value {
+            Maybe::Just(v) => Self::Some(v),
+            Maybe::Nothing => Self::None,
+        }
+    }
+}
+
+#[inline]
+pub(crate) fn lstrip<S: AsRef<[u8]>>(bytes: S) -> Vec<u8> {
+    bytes
+        .as_ref()
+        .iter()
+        .skip_while(|&&x| x == 0)
+        .copied()
+        .collect()
+}
+
+#[inline]
+pub(crate) fn static_left_pad<const N: usize>(
+    data: &[u8],
+) -> Result<[u8; N], open_fastrlp::DecodeError> {
+    if data.len() > N {
+        return Err(open_fastrlp::DecodeError::Overflow);
+    }
+
+    let mut v = [0; N];
+
+    if data.is_empty() {
+        return Ok(v);
+    }
+
+    if data[0] == 0 {
+        return Err(open_fastrlp::DecodeError::LeadingZero);
+    }
+
+    // SAFETY: length checked above
+    unsafe { v.get_unchecked_mut(N - data.len()..) }.copy_from_slice(data);
+    Ok(v)
+}

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1,160 +1,52 @@
 //! VeChain transactions support.
 
 use crate::address::{Address, AddressConvertible, PrivateKey};
+use crate::rlp::{
+    lstrip, static_left_pad, AsBytes, AsVec, BufMut, Bytes, BytesMut, Decodable, Encodable, Maybe,
+    RLPError,
+};
 use crate::utils::blake2_256;
-use alloy_rlp::{Buf, BufMut, RlpDecodable, RlpEncodable};
-pub use alloy_rlp::{Bytes, Decodable, Encodable};
-use ethereum_types::U256;
+use crate::{rlp_encodable, U256};
 use secp256k1::ecdsa::{RecoverableSignature, RecoveryId};
 use secp256k1::{Message, PublicKey, Secp256k1};
 
-pub(crate) fn lstrip<S: AsRef<[u8]>>(bytes: S) -> Vec<u8> {
-    bytes
-        .as_ref()
-        .iter()
-        .skip_while(|&&x| x == 0)
-        .copied()
-        .collect()
+rlp_encodable! {
+    /// Represents a single VeChain transaction.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub struct Transaction {
+        /// Chain tag
+        pub chain_tag: u8,
+        /// Previous block reference
+        ///
+        /// First 4 bytes (BE) are block height, the rest is part of referred block ID.
+        pub block_ref: u64,
+        /// Expiration (in blocks)
+        pub expiration: u32,
+        /// Vector of clauses
+        pub clauses: Vec<Clause>,
+        /// Coefficient to calculate the gas price.
+        pub gas_price_coef: u8,
+        /// Maximal amount of gas to spend for transaction.
+        pub gas: u64,
+        /// Hash of transaction on which current transaction depends.
+        ///
+        /// May be left unspecified if this functionality is not necessary.
+        pub depends_on: Option<U256> => AsBytes<U256>,
+        /// Transaction nonce
+        pub nonce: u64,
+        /// Reserved fields.
+        pub reserved: Option<Reserved> => AsVec<Reserved>,
+        /// Signature. 65 bytes for regular transactions, 130 - for VIP-191.
+        ///
+        /// Ignored when making a signing hash.
+        ///
+        /// For VIP-191 transactions, this would be a simple concatenation
+        /// of two signatures.
+        pub signature: Option<Bytes> => Maybe<Bytes>,
+    }
 }
-
-/// Represents a single VeChain transaction.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Transaction {
-    /// Chain tag
-    pub chain_tag: u8,
-    /// Previous block reference
-    ///
-    /// First 4 bytes (BE) are block height, the rest is part of referred block ID.
-    pub block_ref: u64,
-    /// Expiration (in blocks)
-    pub expiration: u32,
-    /// Vector of clauses
-    pub clauses: Vec<Clause>,
-    /// Coefficient to calculate the gas price.
-    pub gas_price_coef: u8,
-    /// Maximal amount of gas to spend for transaction.
-    pub gas: u64,
-    /// Hash of transaction on which current transaction depends.
-    ///
-    /// May be left unspecified if this functionality is not necessary.
-    pub depends_on: Option<U256>,
-    /// Transaction nonce
-    pub nonce: u64,
-    /// Reserved fields.
-    pub reserved: Option<Reserved>,
-    /// Signature. 65 bytes for regular transactions, 130 - for VIP-191.
-    ///
-    /// Ignored when making a signing hash.
-    ///
-    /// For VIP-191 transactions, this would be a simple concatenation
-    /// of two signatures.
-    pub signature: Option<Bytes>,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, RlpEncodable, RlpDecodable)]
-struct WrappedInternalTransaction {
-    body: InternalTransaction,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct InternalTransaction(Transaction);
 
 // TODO: add serde optional support
-impl Encodable for InternalTransaction {
-    fn encode(&self, out: &mut dyn BufMut) {
-        self.0.chain_tag.encode(out);
-        self.0.block_ref.encode(out);
-        self.0.expiration.encode(out);
-        self.0.clauses.encode(out);
-        self.0.gas_price_coef.encode(out);
-        self.0.gas.encode(out);
-        if let Some(a) = self.0.depends_on.as_ref() {
-            let mut buf = [0; 32];
-            a.to_big_endian(&mut buf);
-            Bytes::copy_from_slice(&buf).encode(out)
-        } else {
-            Bytes::new().encode(out);
-        }
-        self.0.nonce.encode(out);
-        if let Some(r) = self.0.reserved.as_ref() {
-            r.encode(out)
-        } else {
-            b"".to_vec().encode(out);
-        }
-        if let Some(s) = self.0.signature.as_ref() {
-            s.encode(out);
-        }
-    }
-}
-impl Decodable for InternalTransaction {
-    fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
-        alloy_rlp::Header::decode(buf)?;
-        let tx = Self(Transaction {
-            chain_tag: u8::decode(buf)?,
-            block_ref: u64::decode(buf)?,
-            expiration: u32::decode(buf)?,
-            clauses: Vec::<Clause>::decode(buf)?,
-            gas_price_coef: u8::decode(buf)?,
-            gas: u64::decode(buf)?,
-            depends_on: {
-                let binary = Bytes::decode(buf)?;
-                if binary.is_empty() {
-                    None
-                } else {
-                    Some(U256::from_big_endian(
-                        &static_left_pad::<32>(&binary).map_err(|_| {
-                            alloy_rlp::Error::ListLengthMismatch {
-                                expected: 32,
-                                got: binary.len(),
-                            }
-                        })?,
-                    ))
-                }
-            },
-            nonce: u64::decode(buf)?,
-            reserved: {
-                let reserved = Reserved::decode(buf)?;
-                if reserved.is_empty() {
-                    None
-                } else {
-                    Some(reserved)
-                }
-            },
-            signature: {
-                if buf.remaining() == 0 {
-                    None
-                } else {
-                    Some(Bytes::decode(buf)?)
-                }
-            },
-        });
-        if tx.0.signature_length_valid() {
-            Ok(tx)
-        } else {
-            Err(alloy_rlp::Error::ListLengthMismatch {
-                expected: if tx.0.is_delegated() { 130 } else { 65 },
-                got: tx.0.signature.expect("Already checked to be present").len(),
-            })
-        }
-    }
-}
-
-impl Encodable for Transaction {
-    fn encode(&self, out: &mut dyn BufMut) {
-        WrappedInternalTransaction {
-            body: InternalTransaction(self.clone()),
-        }
-        .encode(out)
-    }
-}
-impl Decodable for Transaction {
-    fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
-        let WrappedInternalTransaction {
-            body: InternalTransaction(clause),
-        } = WrappedInternalTransaction::decode(buf)?;
-        Ok(clause)
-    }
-}
 
 impl Transaction {
     /// Gas cost for whole transaction execution.
@@ -173,11 +65,7 @@ impl Transaction {
         //! Get a signing hash for this transaction with fee delegation.
         //!
         //! `VIP-191 <https://github.com/vechain/VIPs/blob/master/vips/VIP-191.md>`
-        let mut encoded = Vec::with_capacity(1024);
-        let mut without_signature = self.clone();
-        without_signature.signature = None;
-        without_signature.encode(&mut encoded);
-        let main_hash = blake2_256(&[encoded]);
+        let main_hash = self.get_signing_hash();
         blake2_256(&[&main_hash[..], &delegate_for.to_fixed_bytes()[..]])
     }
 
@@ -349,7 +237,7 @@ impl Transaction {
         //!
         //! Returns `Err(secp256k1::Error::IncorrectSignature)` if signature is not set.
         if self.signature.is_some() {
-            let mut buf = alloy_rlp::BytesMut::new();
+            let mut buf = BytesMut::new();
             self.encode(&mut buf);
             Ok(buf.into())
         } else {
@@ -358,69 +246,16 @@ impl Transaction {
     }
 }
 
-/// Represents a single transaction clause (recipient, value and data).
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Clause {
-    /// Recipient
-    pub to: Option<Address>,
-    /// Amount of funds to spend.
-    pub value: U256,
-    /// Contract code or other data.
-    pub data: Bytes,
-}
-
-#[derive(Clone)]
-struct InternalClause(Clause);
-#[derive(Clone, RlpEncodable, RlpDecodable)]
-struct WrappedInternalClause(InternalClause);
-
-impl Encodable for Clause {
-    fn encode(&self, out: &mut dyn BufMut) {
-        WrappedInternalClause(InternalClause(self.clone())).encode(out)
-    }
-}
-impl Decodable for Clause {
-    fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
-        let WrappedInternalClause(InternalClause(clause)) = WrappedInternalClause::decode(buf)?;
-        Ok(clause)
-    }
-}
-
-impl Encodable for InternalClause {
-    fn encode(&self, out: &mut dyn BufMut) {
-        if let Some(a) = self.0.to {
-            a.encode(out)
-        } else {
-            Bytes::new().encode(out);
-        }
-
-        let value = {
-            let mut buf = [0; 32];
-            self.0.value.to_big_endian(&mut buf);
-            lstrip(buf)
-        };
-        Bytes::from(value).encode(out);
-
-        self.0.data.encode(out);
-    }
-}
-impl Decodable for InternalClause {
-    fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
-        Ok(Self(Clause {
-            to: {
-                let address = Address::decode(buf)?;
-                if address.to_fixed_bytes() == [0; 20] {
-                    // None is zero address (contract creation). It is not
-                    // distinguishable from real [0; 20] address by design:
-                    // null address is a really existing one, parent of contracts.
-                    None
-                } else {
-                    Some(address)
-                }
-            },
-            value: U256::from_big_endian(&static_left_pad::<32>(&Bytes::decode(buf)?)?),
-            data: Bytes::decode(buf)?,
-        }))
+rlp_encodable! {
+    /// Represents a single transaction clause (recipient, value and data).
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub struct Clause {
+        /// Recipient
+        pub to: Option<Address> => AsBytes<Address>,
+        /// Amount of funds to spend.
+        pub value: U256,
+        /// Contract code or other data.
+        pub data: Bytes,
     }
 }
 
@@ -485,7 +320,7 @@ impl Encodable for Reserved {
 }
 
 impl Decodable for Reserved {
-    fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
+    fn decode(buf: &mut &[u8]) -> Result<Self, RLPError> {
         if let Some((feature_bytes, unused)) = Vec::<Bytes>::decode(buf)?.split_first() {
             Ok(Self {
                 features: u32::from_be_bytes(static_left_pad(feature_bytes)?),
@@ -523,25 +358,4 @@ impl Reserved {
         //! Belongs to delegated transaction?
         self.features == 0 && self.unused.is_empty()
     }
-}
-
-#[inline]
-pub(crate) fn static_left_pad<const N: usize>(data: &[u8]) -> Result<[u8; N], alloy_rlp::Error> {
-    if data.len() > N {
-        return Err(alloy_rlp::Error::Overflow);
-    }
-
-    let mut v = [0; N];
-
-    if data.is_empty() {
-        return Ok(v);
-    }
-
-    if data[0] == 0 {
-        return Err(alloy_rlp::Error::LeadingZero);
-    }
-
-    // SAFETY: length checked above
-    unsafe { v.get_unchecked_mut(N - data.len()..) }.copy_from_slice(data);
-    Ok(v)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,12 +24,14 @@ pub fn keccak<S: AsRef<[u8]>>(bytes: S) -> [u8; 32] {
 
 #[cfg(feature = "serde")]
 pub(crate) mod unhex {
+    use crate::U256;
     use rustc_hex::{FromHex, ToHex};
     use serde::de::Error;
     use serde::{Deserialize, Deserializer, Serializer};
     use serde_with::de::DeserializeAs;
     use serde_with::formats::{Format, Lowercase, Uppercase};
     use serde_with::ser::SerializeAs;
+    use std::any::type_name;
     use std::borrow::Cow;
     use std::convert::{TryFrom, TryInto};
     use std::marker::PhantomData;
@@ -37,22 +39,17 @@ pub(crate) mod unhex {
     #[derive(Copy, Clone, Debug, Default)]
     pub struct Hex<FORMAT: Format = Lowercase>(PhantomData<FORMAT>);
 
-    impl<T: ToHex> SerializeAs<T> for Hex<Lowercase> {
-        fn serialize_as<S>(source: &T, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-        {
-            serializer.serialize_str(&("0x".to_string() + &source.to_hex::<String>()))
+    impl<T: AsRef<[u8]>> SerializeAs<T> for Hex<Lowercase> {
+        fn serialize_as<S: Serializer>(source: &T, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.serialize_str(&("0x".to_string() + &source.as_ref().to_hex::<String>()))
         }
     }
 
-    impl<T: ToHex> SerializeAs<T> for Hex<Uppercase> {
-        fn serialize_as<S>(source: &T, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-        {
-            serializer
-                .serialize_str(&("0x".to_string() + &source.to_hex::<String>().to_uppercase()))
+    impl<T: AsRef<[u8]>> SerializeAs<T> for Hex<Uppercase> {
+        fn serialize_as<S: Serializer>(source: &T, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.serialize_str(
+                &("0x".to_string() + &source.as_ref().to_hex::<String>().to_uppercase()),
+            )
         }
     }
 
@@ -64,20 +61,380 @@ pub(crate) mod unhex {
         fn deserialize_as<D: Deserializer<'de>>(deserializer: D) -> Result<T, D::Error> {
             <Cow<'de, str> as Deserialize<'de>>::deserialize(deserializer)
                 .and_then(|s| {
-                    s.strip_prefix("0x").unwrap_or(&s).from_hex().map_err(|e| {
-                        println!("{:?}", e);
-                        Error::custom(e)
-                    })
+                    s.strip_prefix("0x")
+                        .unwrap_or(&s)
+                        .from_hex()
+                        .map_err(Error::custom)
                 })
                 .and_then(|vec: Vec<u8>| {
                     let length = vec.len();
                     vec.try_into().map_err(|_e: T::Error| {
                         Error::custom(format!(
-                            "Can't convert a Byte Vector of length {} to the output type.",
-                            length
+                            "Can't convert a Byte Vector of length {} to {}",
+                            length,
+                            type_name::<T>(),
                         ))
                     })
                 })
         }
+    }
+
+    pub trait BeBytesConvertible<const N: usize>
+    where
+        Self: Sized,
+    {
+        fn from_be_bytes(src: [u8; N]) -> Self;
+        fn to_be_bytes_(self) -> [u8; N];
+    }
+
+    macro_rules! impl_from_be_bytes {
+        ($t:ty) => {
+            impl BeBytesConvertible<{ <$t>::BITS as usize / 8 }> for $t {
+                fn from_be_bytes(src: [u8; <$t>::BITS as usize / 8]) -> Self {
+                    Self::from_be_bytes(src)
+                }
+                fn to_be_bytes_(self) -> [u8; <$t>::BITS as usize / 8] {
+                    self.to_be_bytes()
+                }
+            }
+        };
+    }
+    impl_from_be_bytes!(u64);
+    impl_from_be_bytes!(u32);
+    impl_from_be_bytes!(u16);
+    impl BeBytesConvertible<32> for U256 {
+        fn from_be_bytes(src: [u8; 32]) -> Self {
+            Self::from_big_endian(&src)
+        }
+        fn to_be_bytes_(self) -> [u8; 32] {
+            let mut buf = [0; 32];
+            self.to_big_endian(&mut buf);
+            buf
+        }
+    }
+
+    impl BeBytesConvertible<1> for u8 {
+        fn from_be_bytes(src: [u8; 1]) -> Self {
+            src[0]
+        }
+        fn to_be_bytes_(self) -> [u8; 1] {
+            [self]
+        }
+    }
+
+    #[derive(Copy, Clone, Debug, Default)]
+    pub struct HexNum<const N: usize, Type: BeBytesConvertible<N>, FORMAT: Format = Lowercase>(
+        PhantomData<Type>,
+        PhantomData<FORMAT>,
+    );
+
+    impl<const N: usize, T: Copy + BeBytesConvertible<N>> SerializeAs<T> for HexNum<N, T, Lowercase> {
+        fn serialize_as<S: Serializer>(source: &T, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer
+                .serialize_str(&("0x".to_string() + &source.to_be_bytes_().to_hex::<String>()))
+        }
+    }
+
+    impl<const N: usize, T: Copy + BeBytesConvertible<N>> SerializeAs<T> for HexNum<N, T, Uppercase> {
+        fn serialize_as<S: Serializer>(source: &T, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.serialize_str(
+                &("0x".to_string() + &source.to_be_bytes_().to_hex::<String>().to_uppercase()),
+            )
+        }
+    }
+
+    impl<'de, const N: usize, Type: BeBytesConvertible<N>, T, FORMAT> DeserializeAs<'de, T>
+        for HexNum<N, Type, FORMAT>
+    where
+        T: From<Type>,
+        FORMAT: Format,
+    {
+        fn deserialize_as<D: Deserializer<'de>>(deserializer: D) -> Result<T, D::Error> {
+            <Cow<'de, str> as Deserialize<'de>>::deserialize(deserializer)
+                .and_then(|s| {
+                    let stripped = s.strip_prefix("0x").unwrap_or(&s);
+                    let padded = if stripped.len() % 2 == 0 {
+                        stripped.to_string()
+                    } else {
+                        "0".to_string() + stripped
+                    };
+                    padded.from_hex().map_err(Error::custom)
+                })
+                .and_then(|vec: Vec<u8>| {
+                    let length = vec.len();
+                    Ok(Type::from_be_bytes(static_left_pad::<N>(&vec).map_err(|_| {
+                        Error::custom(format!(
+                            "Can't convert a Byte Vector of length {} to {}",
+                            length,
+                            type_name::<Type>(),
+                        ))
+                    })?)
+                    .into())
+                })
+        }
+    }
+
+    #[inline]
+    #[cfg(not(tarpaulin_include))]
+    fn static_left_pad<const N: usize>(data: &[u8]) -> Result<[u8; N], open_fastrlp::DecodeError> {
+        // Similar to RLP padding, but allows leading zero. Tested there.
+        if data.len() > N {
+            return Err(open_fastrlp::DecodeError::Overflow);
+        }
+
+        let mut v = [0; N];
+
+        if data.is_empty() {
+            return Ok(v);
+        }
+
+        // SAFETY: length checked above
+        unsafe { v.get_unchecked_mut(N - data.len()..) }.copy_from_slice(data);
+        Ok(v)
+    }
+}
+
+#[cfg(feature = "serde")]
+#[cfg(test)]
+mod test {
+    use super::super::rlp::Bytes;
+    use super::super::U256;
+    use super::unhex::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json::{from_str, json, to_value};
+    use serde_with::formats::{Lowercase, Uppercase};
+
+    #[test]
+    fn test_numbers() {
+        #[serde_with::serde_as]
+        #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+        struct Test {
+            #[serde_as(as = "HexNum<1, u8>")]
+            a: u8,
+            #[serde_as(as = "HexNum<2, u16>")]
+            b: u16,
+            #[serde_as(as = "HexNum<4, u32>")]
+            c: u32,
+            #[serde_as(as = "HexNum<8, u64>")]
+            d: u64,
+            #[serde_as(as = "HexNum<32, U256>")]
+            e: U256,
+        }
+        assert_eq!(
+            to_value(Test {
+                a: 0,
+                b: 0,
+                c: 0,
+                d: 0,
+                e: 0.into()
+            })
+            .expect("Works"),
+            json! {{
+                "a": "0x00",
+                "b": "0x0000",
+                "c": "0x00000000",
+                "d": "0x0000000000000000",
+                "e": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            }}
+        );
+        assert_eq!(
+            from_str::<Test>(
+                r#"{
+                "a": "0x00",
+                "b": "0x0000",
+                "c": "0x00000000",
+                "d": "0x0000000000000000",
+                "e": "0x0000000000000000000000000000000000000000000000000000000000000000"
+            }"#
+            )
+            .expect("Must parse"),
+            Test {
+                a: 0,
+                b: 0,
+                c: 0,
+                d: 0,
+                e: 0.into()
+            },
+        );
+    }
+
+    #[test]
+    fn test_numbers_padding() {
+        #[serde_with::serde_as]
+        #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+        struct Test {
+            #[serde_as(as = "HexNum<2, u16>")]
+            a: u16,
+        }
+        assert_eq!(
+            from_str::<Test>(r#"{"a": "0x1"}"#).expect("Must parse"),
+            Test { a: 1_u16 },
+        );
+    }
+
+    #[test]
+    fn test_numbers_fail_too_long() {
+        #[serde_with::serde_as]
+        #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+        struct Test {
+            #[serde_as(as = "HexNum<2, u16>")]
+            a: u16,
+        }
+        assert_eq!(
+            from_str::<Test>(r#"{"a": "0x01010101"}"#)
+                .expect_err("Must not parse")
+                .to_string(),
+            "Can't convert a Byte Vector of length 4 to u16 at line 1 column 19"
+        );
+    }
+
+    #[test]
+    fn test_wrapped_numbers() {
+        #[serde_with::serde_as]
+        #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+        struct Test {
+            #[serde_as(as = "Option<HexNum<1, u8, Uppercase>>")]
+            a: Option<u8>,
+            #[serde_as(as = "Option<HexNum<1, u8>>")]
+            b: Option<u8>,
+            #[serde_as(as = "Vec<HexNum<2, u16, Lowercase>>")]
+            c: Vec<u16>,
+        }
+        assert_eq!(
+            to_value(Test {
+                a: Some(0x0F),
+                b: None,
+                c: vec![1, 0x0E],
+            })
+            .expect("Works"),
+            json! {{
+                "a": "0x0F",
+                "b": Option::<u8>::None,
+                "c": vec!["0x0001", "0x000e"],
+            }}
+        );
+        assert_eq!(
+            from_str::<Test>(
+                r#"{
+                "a": "0x0f",
+                "b": null,
+                "c": ["0x0001", "0x000E"]
+            }"#
+            )
+            .expect("Must parse"),
+            Test {
+                a: Some(0x0F),
+                b: None,
+                c: vec![1, 0x0E],
+            }
+        );
+    }
+
+    #[test]
+    fn test_hex_strings() {
+        #[serde_with::serde_as]
+        #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+        struct Test {
+            #[serde_as(as = "Option<Hex>")]
+            a: Option<Vec<u8>>,
+            #[serde_as(as = "Option<Hex<Lowercase>>")]
+            b: Option<Bytes>,
+            #[serde_as(as = "Option<Hex<Lowercase>>")]
+            c: Option<Bytes>,
+            #[serde_as(as = "Vec<Hex<Uppercase>>")]
+            d: Vec<Bytes>,
+            #[serde_as(as = "Vec<Hex<Uppercase>>")]
+            e: Vec<Bytes>,
+            #[serde_as(as = "Vec<Hex<Lowercase>>")]
+            f: Vec<Bytes>,
+        }
+        assert_eq!(
+            to_value(Test {
+                a: Some(vec![]),
+                b: None,
+                c: Some(Bytes::copy_from_slice(&b"\x01\x0F"[..])),
+                d: vec![Bytes::copy_from_slice(&b"\x01\x0F"[..])],
+                e: vec![],
+                f: vec![Bytes::copy_from_slice(&b"\x01\x0F"[..])],
+            })
+            .expect("Works"),
+            json! {{
+                "a": "0x",
+                "b": Option::<u8>::None,
+                "c": "0x010f",
+                "d": vec!["0x010F"],
+                "e": Vec::<u8>::new(),
+                "f": vec!["0x010f"]
+            }}
+        );
+        assert_eq!(
+            from_str::<Test>(
+                r#"{
+                "a": "0x",
+                "b": null,
+                "c": "0x010f",
+                "d": ["0x010F"],
+                "e": [],
+                "f": ["0x010f"]
+            }"#
+            )
+            .expect("Must parse"),
+            Test {
+                a: Some(vec![]),
+                b: None,
+                c: Some(Bytes::copy_from_slice(&b"\x01\x0F"[..])),
+                d: vec![Bytes::copy_from_slice(&b"\x01\x0F"[..])],
+                e: vec![],
+                f: vec![Bytes::copy_from_slice(&b"\x01\x0F"[..])],
+            }
+        );
+    }
+
+    #[test]
+    fn test_string_fail_too_long() {
+        #[serde_with::serde_as]
+        #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+        struct Test {
+            #[serde_as(as = "Hex")]
+            a: [u8; 3],
+        }
+        assert_eq!(
+            from_str::<Test>(r#"{"a": "0x01010101"}"#)
+                .expect_err("Must not parse")
+                .to_string(),
+            "Can't convert a Byte Vector of length 4 to [u8; 3] at line 1 column 19"
+        );
+    }
+
+    #[test]
+    fn test_string_fail_too_short() {
+        #[serde_with::serde_as]
+        #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+        struct Test {
+            #[serde_as(as = "Hex")]
+            a: [u8; 5],
+        }
+        assert_eq!(
+            from_str::<Test>(r#"{"a": "0x01010101"}"#)
+                .expect_err("Must not parse")
+                .to_string(),
+            "Can't convert a Byte Vector of length 4 to [u8; 5] at line 1 column 19"
+        );
+    }
+
+    #[test]
+    fn test_string_fail_bad_hex() {
+        #[serde_with::serde_as]
+        #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+        struct Test {
+            #[serde_as(as = "Hex")]
+            a: [u8; 5],
+        }
+        assert_eq!(
+            from_str::<Test>(r#"{"a": "0x0101010G"}"#)
+                .expect_err("Must not parse")
+                .to_string(),
+            "Invalid character 'G' at position 7 at line 1 column 19"
+        );
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,3 @@
-use crate::address::AddressValidationError;
 use blake2::{digest::consts::U32, Blake2b, Digest};
 use tiny_keccak::{Hasher, Keccak};
 
@@ -21,22 +20,4 @@ pub fn keccak<S: AsRef<[u8]>>(bytes: S) -> [u8; 32] {
     let mut hash = [0; 32];
     hasher.finalize(&mut hash);
     hash
-}
-
-#[cfg(not(tarpaulin_include))]
-pub fn decode_hex(s: &str) -> Result<Vec<u8>, AddressValidationError> {
-    //! Convert a hex string (with or without 0x prefix) to binary.
-    let prefix = if s.starts_with("0x") { 2 } else { 0 };
-    (0..s.len())
-        .skip(prefix)
-        .step_by(2)
-        .map(|i| {
-            u8::from_str_radix(
-                s.get(i..i + 2)
-                    .ok_or(AddressValidationError::InvalidLength)?,
-                16,
-            )
-            .map_err(|_| AddressValidationError::InvalidHex)
-        })
-        .collect()
 }

--- a/tests/test_address.rs
+++ b/tests/test_address.rs
@@ -1,4 +1,4 @@
-use thor_devkit::address::*;
+use thor_devkit::{Address, AddressConvertible, PublicKey};
 
 #[test]
 fn test_upubkey_to_address() {

--- a/tests/test_hdnode.rs
+++ b/tests/test_hdnode.rs
@@ -1,11 +1,15 @@
 use bip32::{ExtendedKey, ExtendedKeyAttrs, Prefix};
-use thor_devkit::decode_hex;
+use rustc_hex::FromHex;
 use thor_devkit::hdnode::*;
+
+fn decode_hex(hex: &str) -> Vec<u8> {
+    hex.from_hex().unwrap()
+}
 
 #[test]
 fn test_from_seed() {
     //! Test vectors from https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
-    let seed = decode_hex("fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542").unwrap();
+    let seed = decode_hex("fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542");
     let node = HDNode::build()
         .seed(seed.clone().try_into().unwrap())
         .path("m".parse().unwrap())
@@ -56,12 +60,12 @@ fn test_from_mnemonic_vet() {
             .public_key()
             .serialize_uncompressed()
             .to_vec(),
-        decode_hex(public).unwrap(),
+        decode_hex(public),
         "Public key differs"
     );
     assert_eq!(
         node.chain_code().to_vec(),
-        decode_hex(chain_code).unwrap(),
+        decode_hex(chain_code),
         "Chain code differs"
     );
     let same_node = HDNode::build()
@@ -118,7 +122,7 @@ fn test_from_mnemonic_vet() {
 #[test]
 fn test_derive() {
     //! Test vectors from https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
-    let seed = decode_hex("fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542").unwrap();
+    let seed = decode_hex("fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542");
     // Not hardened
     let node = HDNode::build()
         .seed(seed.clone().try_into().unwrap())
@@ -271,7 +275,6 @@ fn test_build() {
     HDNode::build()
         .master_private_key_bytes(
             decode_hex("00e4a2687ec443f4d23b6ba9e7d904a31acdda90032b34aa0e642e6dd3fd36f682")
-                .unwrap()
                 .try_into()
                 .unwrap(),
             [0; 32],
@@ -281,7 +284,6 @@ fn test_build() {
     HDNode::build()
         .master_public_key_bytes(
             decode_hex("035A784662A4A20A65BF6AAB9AE98A6C068A81C52E4B032C0FB5400C706CFCCC56")
-                .unwrap()
                 .try_into()
                 .unwrap(),
             [0; 32],

--- a/tests/test_network.rs
+++ b/tests/test_network.rs
@@ -12,23 +12,112 @@ mod test_network {
     use thor_devkit::rlp::Bytes;
     use thor_devkit::transactions::*;
 
-    #[tokio::test]
-    async fn test_fetch_existing() {
-        let client = ThorNode::testnet();
-        let (tx, meta) = client
-            .fetch_transaction(
-                decode_hex("ea4c3d8b830f777ae55052bd92f2c65ae9f6c36eb391ac52e8e77d5d2bf5f308")
-                    .try_into()
-                    .unwrap(),
-            )
-            .await
+    fn existing_tx_id() -> [u8; 32] {
+        decode_hex("ea4c3d8b830f777ae55052bd92f2c65ae9f6c36eb391ac52e8e77d5d2bf5f308")
+            .try_into()
             .unwrap()
-            .expect("Must be found");
+    }
+    fn existing_block_id() -> [u8; 32] {
+        decode_hex("0107b6875c70deb02eda7a6724891e7774b34b8aecc57d2898f36384c6a6868c")
+            .try_into()
+            .unwrap()
+    }
+
+    fn transaction_details() -> (Transaction, TransactionMeta) {
         let clause_data = b"\xb3\x91\xc7\xd3vtho-usd\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x84\x17\x19\x1a\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0e\x7f\x8eJ";
-        let signature =b"\xbf3\xd0\0\xd9\xa8\x93\x10\xd4\xda\xddy@\x03\xd5\x1e.\x86\x80\x8b#HQ)\xa4|\xcaE\xf5>Ib_\xd3q>?i\x99\x17X\xc5u\xf7\x12\xc7\xd23\x15\xf6\xe6Z+D\xd3\x19\x0b\xf7\x0c\r=\x85{\xc6\0\x8d5\xb2\xf1\xff\xe2b4\x8d\x17yj\x9a\xc1%\xf8\x9e\xe2b\x83\xa4\xf9F\xb79H\xe6\x80\x11\x1eWTm\x08\x8b\xec\t1\xe3\xae\\7\xae\xe2e\xc9\xaa|\x11L\xfc\x87h\xabi\xe1L\xeez\xdc\x90\xdb\r\xfc\x01";
-        assert_eq!(
-            tx,
-            Transaction {
+        let signature = b"\xbf3\xd0\0\xd9\xa8\x93\x10\xd4\xda\xddy@\x03\xd5\x1e.\x86\x80\x8b#HQ)\xa4|\xcaE\xf5>Ib_\xd3q>?i\x99\x17X\xc5u\xf7\x12\xc7\xd23\x15\xf6\xe6Z+D\xd3\x19\x0b\xf7\x0c\r=\x85{\xc6\0\x8d5\xb2\xf1\xff\xe2b4\x8d\x17yj\x9a\xc1%\xf8\x9e\xe2b\x83\xa4\xf9F\xb79H\xe6\x80\x11\x1eWTm\x08\x8b\xec\t1\xe3\xae\\7\xae\xe2e\xc9\xaa|\x11L\xfc\x87h\xabi\xe1L\xeez\xdc\x90\xdb\r\xfc\x01";
+
+        let tx = Transaction {
+            chain_tag: 39,
+            block_ref: 74228606445726694,
+            expiration: 32,
+            clauses: vec![Clause {
+                to: Some(
+                    "0x12e3582d7ca22234f39d2a7be12c98ea9c077e25"
+                        .parse()
+                        .unwrap(),
+                ),
+                value: 0.into(),
+                data: Bytes::copy_from_slice(&clause_data[..]),
+            }],
+            gas_price_coef: 128,
+            gas: 79481,
+            depends_on: None,
+            nonce: 1702858315418,
+            reserved: Some(Reserved {
+                features: 1,
+                unused: vec![],
+            }),
+            signature: Some(Bytes::copy_from_slice(&signature[..])),
+        };
+        let meta = TransactionMeta {
+            block_id: "0107b6875c70deb02eda7a6724891e7774b34b8aecc57d2898f36384c6a6868c"
+                .from_hex::<Vec<u8>>()
+                .unwrap()
+                .try_into()
+                .unwrap(),
+            block_number: 17282695,
+            block_timestamp: 1702858320,
+        };
+        (tx, meta)
+    }
+    fn block_details() -> (BlockInfo, Vec<BlockTransaction>) {
+        let info = BlockInfo {
+            number: 17282695,
+            id: existing_block_id(),
+            size: 655,
+            parent_id: decode_hex(
+                "0107b686375eabe6821225b0218ef5d51d0933756ca95d558c0a6b010f45f503",
+            )
+            .try_into()
+            .unwrap(),
+            timestamp: 1702858320,
+            gas_limit: 30000000,
+            beneficiary: "0xb4094c25f86d628fdd571afc4077f0d0196afb48"
+                .parse()
+                .unwrap(),
+            gas_used: 37918,
+            total_score: 136509202,
+            txs_root: decode_hex(
+                "0e3d83681601227e22c2eaa3dd5ef1c3301fe23dd7db21ac15984d7b6e2c6552",
+            )
+            .try_into()
+            .unwrap(),
+            txs_features: 1,
+            state_root: decode_hex(
+                "dc94484d4f0d01b068dc1d66c5731dd36b32ba3b08bcfad977d599e5c9342dd1",
+            )
+            .try_into()
+            .unwrap(),
+            receipts_root: decode_hex(
+                "df5066746c62904390f2312e81fb7a98811098627a2ae8474457e69cd60b846a",
+            )
+            .try_into()
+            .unwrap(),
+            com: true,
+            signer: "0x0771bc0fe8b6dcf72372440c79a309e92ffb93e8"
+                .parse()
+                .unwrap(),
+            is_trunk: true,
+            is_finalized: true,
+        };
+        let clause_data= b"\xb3\x91\xc7\xd3vtho-usd\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x84\x17\x19\x1a\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0e\x7f\x8eJ";
+        let exec_data= b"vtho-usd\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x84\x17\x19\x1a\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0e\x7f\x8eJ";
+        let transaction = BlockTransaction {
+            transaction: ExtendedTransaction {
+                id: [
+                    234, 76, 61, 139, 131, 15, 119, 122, 229, 80, 82, 189, 146, 242, 198, 90, 233,
+                    246, 195, 110, 179, 145, 172, 82, 232, 231, 125, 93, 43, 245, 243, 8,
+                ],
+                origin: "0x56cb0e0276ad689cc68954d47460cd70f46244dc"
+                    .parse()
+                    .unwrap(),
+                delegator: Some(
+                    "0xeedfd966da350803ba7fc8f40f6a3151164e2058"
+                        .parse()
+                        .unwrap(),
+                ),
+                size: 290,
                 chain_tag: 39,
                 block_ref: 74228606445726694,
                 expiration: 32,
@@ -36,47 +125,118 @@ mod test_network {
                     to: Some(
                         "0x12e3582d7ca22234f39d2a7be12c98ea9c077e25"
                             .parse()
-                            .unwrap()
+                            .unwrap(),
                     ),
                     value: 0.into(),
-                    data: Bytes::copy_from_slice(&clause_data[..])
+                    data: Bytes::copy_from_slice(clause_data),
                 }],
                 gas_price_coef: 128,
                 gas: 79481,
                 depends_on: None,
                 nonce: 1702858315418,
-                reserved: Some(Reserved {
-                    features: 1,
-                    unused: vec![]
-                }),
-                signature: Some(Bytes::copy_from_slice(&signature[..])),
+            },
+            receipt: Receipt {
+                gas_used: 37918,
+                gas_payer: "0xeedfd966da350803ba7fc8f40f6a3151164e2058"
+                    .parse()
+                    .unwrap(),
+                paid: 569513490196068766_u128.into(),
+                reward: 170854047058820629_u128.into(),
+                reverted: false,
+                outputs: vec![ReceiptOutput {
+                    contract_address: None,
+                    events: vec![Event {
+                        address: "0x12e3582d7ca22234f39d2a7be12c98ea9c077e25"
+                            .parse()
+                            .unwrap(),
+                        topics: vec![[
+                            239, 200, 244, 4, 28, 11, 164, 208, 151, 229, 75, 206, 126, 91, 196,
+                            126, 197, 180, 92, 2, 112, 196, 35, 121, 196, 182, 145, 200, 89, 67,
+                            237, 240,
+                        ]],
+                        data: Bytes::copy_from_slice(exec_data),
+                    }],
+                    transfers: vec![],
+                }],
+            },
+        };
+        (info, vec![transaction])
+    }
+
+    #[tokio::test]
+    async fn test_fetch_existing() {
+        let client = ThorNode::testnet();
+        let (tx, meta) = client
+            .fetch_transaction(existing_tx_id())
+            .await
+            .unwrap()
+            .expect("Must be found");
+        let (tx_expected, meta_expected) = transaction_details();
+        assert_eq!(tx, tx_expected);
+        assert_eq!(meta.expect("Meta should be found"), meta_expected);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_existing_ext() {
+        let client = ThorNode::testnet();
+        let (tx, meta) = client
+            .fetch_extended_transaction(existing_tx_id())
+            .await
+            .unwrap()
+            .expect("Must be found");
+        let (tx_expected, meta_expected) = transaction_details();
+        let Transaction {
+            chain_tag,
+            block_ref,
+            expiration,
+            clauses,
+            gas_price_coef,
+            gas,
+            depends_on,
+            nonce,
+            ..
+        } = tx_expected.clone();
+        assert_eq!(
+            tx,
+            ExtendedTransaction {
+                chain_tag,
+                block_ref,
+                expiration,
+                clauses,
+                gas_price_coef,
+                gas,
+                depends_on,
+                nonce,
+                size: 290,
+                delegator: Some(
+                    "0xeedfd966da350803ba7fc8f40f6a3151164e2058"
+                        .parse()
+                        .unwrap()
+                ),
+                id: existing_tx_id(),
+                origin: "0x56cb0e0276ad689cc68954d47460cd70f46244dc"
+                    .parse()
+                    .unwrap()
             }
         );
         assert_eq!(
-            meta.expect("Meta should be found"),
-            TransactionMeta {
-                block_id: "0107b6875c70deb02eda7a6724891e7774b34b8aecc57d2898f36384c6a6868c"
-                    .from_hex::<Vec<u8>>()
-                    .unwrap()
-                    .try_into()
-                    .unwrap(),
-                block_number: 17282695,
-                block_timestamp: 1702858320,
+            tx.as_transaction(),
+            Transaction {
+                signature: None,
+                ..tx_expected
             }
         );
+        assert_eq!(meta.expect("Meta should be found"), meta_expected);
     }
 
     #[tokio::test]
     async fn test_fetch_existing_receipt() {
         let client = ThorNode::testnet();
-        let receipt = client
-            .fetch_transaction_receipt(
-                decode_hex("ea4c3d8b830f777ae55052bd92f2c65ae9f6c36eb391ac52e8e77d5d2bf5f308")
-                    .try_into()
-                    .unwrap(),
-            )
+        let (receipt, meta) = client
+            .fetch_transaction_receipt(existing_tx_id())
             .await
-            .unwrap();
+            .expect("Must not fail")
+            .expect("Must have been found");
         let clause_data = b"vtho-usd\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x84\x17\x19\x1a\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0e\x7f\x8eJ";
         let expected = Receipt {
             gas_used: 37918,
@@ -100,36 +260,38 @@ mod test_network {
                 }],
                 transfers: vec![],
             }],
-            meta: ReceiptMeta {
-                block_id: [
-                    1, 7, 182, 135, 92, 112, 222, 176, 46, 218, 122, 103, 36, 137, 30, 119, 116,
-                    179, 75, 138, 236, 197, 125, 40, 152, 243, 99, 132, 198, 166, 134, 140,
-                ],
-                block_number: 17282695,
-                block_timestamp: 1702858320,
-                tx_id: [
-                    234, 76, 61, 139, 131, 15, 119, 122, 229, 80, 82, 189, 146, 242, 198, 90, 233,
-                    246, 195, 110, 179, 145, 172, 82, 232, 231, 125, 93, 43, 245, 243, 8,
-                ],
-                tx_origin: "0x56cb0e0276ad689cc68954d47460cd70f46244dc"
-                    .parse()
-                    .unwrap(),
-            },
         };
-        assert_eq!(receipt.unwrap(), expected)
+        let expected_meta = ReceiptMeta {
+            block_id: [
+                1, 7, 182, 135, 92, 112, 222, 176, 46, 218, 122, 103, 36, 137, 30, 119, 116, 179,
+                75, 138, 236, 197, 125, 40, 152, 243, 99, 132, 198, 166, 134, 140,
+            ],
+            block_number: 17282695,
+            block_timestamp: 1702858320,
+            tx_id: [
+                234, 76, 61, 139, 131, 15, 119, 122, 229, 80, 82, 189, 146, 242, 198, 90, 233, 246,
+                195, 110, 179, 145, 172, 82, 232, 231, 125, 93, 43, 245, 243, 8,
+            ],
+            tx_origin: "0x56cb0e0276ad689cc68954d47460cd70f46244dc"
+                .parse()
+                .unwrap(),
+        };
+        assert_eq!(receipt, expected);
+        assert_eq!(meta, expected_meta);
     }
 
     #[tokio::test]
     async fn test_fetch_existing_receipt_with_transfers() {
         let client = ThorNode::mainnet();
-        let receipt = client
+        let (receipt, meta) = client
             .fetch_transaction_receipt(
                 decode_hex("1755319a898a52fbceb4c58f51d63e6fa53592678512dd786de953d55895946a")
                     .try_into()
                     .unwrap(),
             )
             .await
-            .unwrap();
+            .expect("Must not fail")
+            .expect("Must have been found");
         let expected = Receipt {
             gas_used: 21000,
             gas_payer: "0xb0c224a96655ba8d51f35f98068f5fc12f930946"
@@ -151,23 +313,98 @@ mod test_network {
                     amount: 5733123118820000000000_u128.into(),
                 }],
             }],
-            meta: ReceiptMeta {
-                block_id: [
-                    1, 7, 123, 88, 83, 194, 165, 215, 242, 232, 190, 239, 4, 90, 10, 32, 219, 20,
-                    208, 49, 108, 178, 89, 39, 71, 129, 5, 138, 112, 103, 10, 247,
-                ],
-                block_number: 17267544,
-                block_timestamp: 1703201660,
-                tx_id: [
-                    23, 85, 49, 154, 137, 138, 82, 251, 206, 180, 197, 143, 81, 214, 62, 111, 165,
-                    53, 146, 103, 133, 18, 221, 120, 109, 233, 83, 213, 88, 149, 148, 106,
-                ],
-                tx_origin: "0xb0c224a96655ba8d51f35f98068f5fc12f930946"
-                    .parse()
-                    .unwrap(),
-            },
         };
-        assert_eq!(receipt.expect("Must be found"), expected)
+        let expected_meta = ReceiptMeta {
+            block_id: [
+                1, 7, 123, 88, 83, 194, 165, 215, 242, 232, 190, 239, 4, 90, 10, 32, 219, 20, 208,
+                49, 108, 178, 89, 39, 71, 129, 5, 138, 112, 103, 10, 247,
+            ],
+            block_number: 17267544,
+            block_timestamp: 1703201660,
+            tx_id: [
+                23, 85, 49, 154, 137, 138, 82, 251, 206, 180, 197, 143, 81, 214, 62, 111, 165, 53,
+                146, 103, 133, 18, 221, 120, 109, 233, 83, 213, 88, 149, 148, 106,
+            ],
+            tx_origin: "0xb0c224a96655ba8d51f35f98068f5fc12f930946"
+                .parse()
+                .unwrap(),
+        };
+        assert_eq!(receipt, expected);
+        assert_eq!(meta, expected_meta);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_block() {
+        let client = ThorNode::testnet();
+        let (blockinfo, transactions) = client
+            .fetch_block(BlockReference::ID(
+                decode_hex("0107b6875c70deb02eda7a6724891e7774b34b8aecc57d2898f36384c6a6868c")
+                    .try_into()
+                    .unwrap(),
+            ))
+            .await
+            .expect("Must not fail")
+            .expect("Must have been found");
+
+        let (expected_info, expected_transactions) = block_details();
+        let expected_transactions: Vec<_> = expected_transactions
+            .into_iter()
+            .map(|t| t.transaction.id)
+            .collect();
+        assert_eq!(blockinfo, expected_info);
+        assert_eq!(transactions, expected_transactions);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_block_by_number() {
+        let client = ThorNode::testnet();
+        let (blockinfo, transactions) = client
+            .fetch_block(BlockReference::Number(0x0107b687))
+            .await
+            .expect("Must not fail")
+            .expect("Must have been found");
+
+        let (expected_info, expected_transactions) = block_details();
+        let expected_transactions: Vec<_> = expected_transactions
+            .into_iter()
+            .map(|t| t.transaction.id)
+            .collect();
+        assert_eq!(blockinfo, expected_info);
+        assert_eq!(transactions, expected_transactions);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_block_latest() {
+        let client = ThorNode::testnet();
+        let res = client
+            .fetch_block(BlockReference::Best)
+            .await
+            .expect("Must not fail");
+        assert!(res.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_block_finalized() {
+        let client = ThorNode::testnet();
+        let res = client
+            .fetch_block(BlockReference::Finalized)
+            .await
+            .expect("Must not fail");
+        assert!(res.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_block_expanded() {
+        let client = ThorNode::testnet();
+        let (blockinfo, transactions) = client
+            .fetch_block_expanded(BlockReference::ID(existing_block_id()))
+            .await
+            .expect("Must not fail")
+            .expect("Must have been found");
+
+        let (expected_info, expected_transactions) = block_details();
+        assert_eq!(blockinfo, expected_info);
+        assert_eq!(transactions, expected_transactions);
     }
 
     #[tokio::test]
@@ -175,6 +412,20 @@ mod test_network {
         let client = ThorNode::testnet();
         let result = client
             .fetch_transaction(
+                decode_hex("ea0c3d8b830f777ae55052bd92f2c65ae9f6c36eb391ac52e8e77d5d2bf5f308")
+                    .try_into()
+                    .unwrap(),
+            )
+            .await
+            .expect("Must not fail");
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_nonexisting_ext() {
+        let client = ThorNode::testnet();
+        let result = client
+            .fetch_extended_transaction(
                 decode_hex("ea0c3d8b830f777ae55052bd92f2c65ae9f6c36eb391ac52e8e77d5d2bf5f308")
                     .try_into()
                     .unwrap(),
@@ -193,6 +444,34 @@ mod test_network {
                     .try_into()
                     .unwrap(),
             )
+            .await
+            .expect("Must not fail");
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_nonexisting_block() {
+        let client = ThorNode::testnet();
+        let result = client
+            .fetch_block(BlockReference::ID(
+                decode_hex("0107b6875c70deb02eda7a6724891e7774b34b8aecc57d2898f36384c6a6868d")
+                    .try_into()
+                    .unwrap(),
+            ))
+            .await
+            .expect("Must not fail");
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_nonexisting_block_ext() {
+        let client = ThorNode::testnet();
+        let result = client
+            .fetch_block_expanded(BlockReference::ID(
+                decode_hex("0107b6875c70deb02eda7a6724891e7774b34b8aecc57d2898f36384c6a6868d")
+                    .try_into()
+                    .unwrap(),
+            ))
             .await
             .expect("Must not fail");
         assert!(result.is_none());

--- a/tests/test_network.rs
+++ b/tests/test_network.rs
@@ -1,0 +1,200 @@
+use rustc_hex::FromHex;
+
+fn decode_hex(hex: &str) -> Vec<u8> {
+    hex.from_hex().unwrap()
+}
+
+#[cfg(feature = "http")]
+#[cfg(test)]
+mod test_network {
+    use super::*;
+    use thor_devkit::network::*;
+    use thor_devkit::rlp::Bytes;
+    use thor_devkit::transactions::*;
+
+    #[tokio::test]
+    async fn test_fetch_existing() {
+        let client = ThorNode::testnet();
+        let (tx, meta) = client
+            .fetch_transaction(
+                decode_hex("ea4c3d8b830f777ae55052bd92f2c65ae9f6c36eb391ac52e8e77d5d2bf5f308")
+                    .try_into()
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+            .expect("Must be found");
+        let clause_data = b"\xb3\x91\xc7\xd3vtho-usd\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x84\x17\x19\x1a\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0e\x7f\x8eJ";
+        let signature =b"\xbf3\xd0\0\xd9\xa8\x93\x10\xd4\xda\xddy@\x03\xd5\x1e.\x86\x80\x8b#HQ)\xa4|\xcaE\xf5>Ib_\xd3q>?i\x99\x17X\xc5u\xf7\x12\xc7\xd23\x15\xf6\xe6Z+D\xd3\x19\x0b\xf7\x0c\r=\x85{\xc6\0\x8d5\xb2\xf1\xff\xe2b4\x8d\x17yj\x9a\xc1%\xf8\x9e\xe2b\x83\xa4\xf9F\xb79H\xe6\x80\x11\x1eWTm\x08\x8b\xec\t1\xe3\xae\\7\xae\xe2e\xc9\xaa|\x11L\xfc\x87h\xabi\xe1L\xeez\xdc\x90\xdb\r\xfc\x01";
+        assert_eq!(
+            tx,
+            Transaction {
+                chain_tag: 39,
+                block_ref: 74228606445726694,
+                expiration: 32,
+                clauses: vec![Clause {
+                    to: Some(
+                        "0x12e3582d7ca22234f39d2a7be12c98ea9c077e25"
+                            .parse()
+                            .unwrap()
+                    ),
+                    value: 0.into(),
+                    data: Bytes::copy_from_slice(&clause_data[..])
+                }],
+                gas_price_coef: 128,
+                gas: 79481,
+                depends_on: None,
+                nonce: 1702858315418,
+                reserved: Some(Reserved {
+                    features: 1,
+                    unused: vec![]
+                }),
+                signature: Some(Bytes::copy_from_slice(&signature[..])),
+            }
+        );
+        assert_eq!(
+            meta.expect("Meta should be found"),
+            TransactionMeta {
+                block_id: "0107b6875c70deb02eda7a6724891e7774b34b8aecc57d2898f36384c6a6868c"
+                    .from_hex::<Vec<u8>>()
+                    .unwrap()
+                    .try_into()
+                    .unwrap(),
+                block_number: 17282695,
+                block_timestamp: 1702858320,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_existing_receipt() {
+        let client = ThorNode::testnet();
+        let receipt = client
+            .fetch_transaction_receipt(
+                decode_hex("ea4c3d8b830f777ae55052bd92f2c65ae9f6c36eb391ac52e8e77d5d2bf5f308")
+                    .try_into()
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let clause_data = b"vtho-usd\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x84\x17\x19\x1a\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0e\x7f\x8eJ";
+        let expected = Receipt {
+            gas_used: 37918,
+            gas_payer: "0xeedfd966da350803ba7fc8f40f6a3151164e2058"
+                .parse()
+                .unwrap(),
+            paid: 569513490196068766_u64.into(),
+            reward: 170854047058820629_u64.into(),
+            reverted: false,
+            outputs: vec![ReceiptOutput {
+                contract_address: None,
+                events: vec![Event {
+                    address: "0x12e3582d7ca22234f39d2a7be12c98ea9c077e25"
+                        .parse()
+                        .unwrap(),
+                    topics: vec![Topic([
+                        239, 200, 244, 4, 28, 11, 164, 208, 151, 229, 75, 206, 126, 91, 196, 126,
+                        197, 180, 92, 2, 112, 196, 35, 121, 196, 182, 145, 200, 89, 67, 237, 240,
+                    ])],
+                    data: Bytes::copy_from_slice(&clause_data[..]),
+                }],
+                transfers: vec![],
+            }],
+            meta: ReceiptMeta {
+                block_id: [
+                    1, 7, 182, 135, 92, 112, 222, 176, 46, 218, 122, 103, 36, 137, 30, 119, 116,
+                    179, 75, 138, 236, 197, 125, 40, 152, 243, 99, 132, 198, 166, 134, 140,
+                ],
+                block_number: 17282695,
+                block_timestamp: 1702858320,
+                tx_id: [
+                    234, 76, 61, 139, 131, 15, 119, 122, 229, 80, 82, 189, 146, 242, 198, 90, 233,
+                    246, 195, 110, 179, 145, 172, 82, 232, 231, 125, 93, 43, 245, 243, 8,
+                ],
+                tx_origin: "0x56cb0e0276ad689cc68954d47460cd70f46244dc"
+                    .parse()
+                    .unwrap(),
+            },
+        };
+        assert_eq!(receipt.unwrap(), expected)
+    }
+
+    #[tokio::test]
+    async fn test_fetch_existing_receipt_with_transfers() {
+        let client = ThorNode::mainnet();
+        let receipt = client
+            .fetch_transaction_receipt(
+                decode_hex("1755319a898a52fbceb4c58f51d63e6fa53592678512dd786de953d55895946a")
+                    .try_into()
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let expected = Receipt {
+            gas_used: 21000,
+            gas_payer: "0xb0c224a96655ba8d51f35f98068f5fc12f930946"
+                .parse()
+                .unwrap(),
+            paid: 210000000000000000_u64.into(),
+            reward: 63000000000000000_u64.into(),
+            reverted: false,
+            outputs: vec![ReceiptOutput {
+                contract_address: None,
+                events: vec![],
+                transfers: vec![Transfer {
+                    sender: "0xb0c224a96655ba8d51f35f98068f5fc12f930946"
+                        .parse()
+                        .unwrap(),
+                    recipient: "0xfe33b406664f7cc03ede326e695c06c211a45a48"
+                        .parse()
+                        .unwrap(),
+                    amount: 5733123118820000000000_u128.into(),
+                }],
+            }],
+            meta: ReceiptMeta {
+                block_id: [
+                    1, 7, 123, 88, 83, 194, 165, 215, 242, 232, 190, 239, 4, 90, 10, 32, 219, 20,
+                    208, 49, 108, 178, 89, 39, 71, 129, 5, 138, 112, 103, 10, 247,
+                ],
+                block_number: 17267544,
+                block_timestamp: 1703201660,
+                tx_id: [
+                    23, 85, 49, 154, 137, 138, 82, 251, 206, 180, 197, 143, 81, 214, 62, 111, 165,
+                    53, 146, 103, 133, 18, 221, 120, 109, 233, 83, 213, 88, 149, 148, 106,
+                ],
+                tx_origin: "0xb0c224a96655ba8d51f35f98068f5fc12f930946"
+                    .parse()
+                    .unwrap(),
+            },
+        };
+        assert_eq!(receipt.expect("Must be found"), expected)
+    }
+
+    #[tokio::test]
+    async fn test_fetch_nonexisting() {
+        let client = ThorNode::testnet();
+        let result = client
+            .fetch_transaction(
+                decode_hex("ea0c3d8b830f777ae55052bd92f2c65ae9f6c36eb391ac52e8e77d5d2bf5f308")
+                    .try_into()
+                    .unwrap(),
+            )
+            .await
+            .expect("Must not fail");
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_nonexisting_receipt() {
+        let client = ThorNode::testnet();
+        let result = client
+            .fetch_transaction_receipt(
+                decode_hex("ea0c3d8b830f777ae55052bd92f2c65ae9f6c36eb391ac52e8e77d5d2bf5f308")
+                    .try_into()
+                    .unwrap(),
+            )
+            .await
+            .expect("Must not fail");
+        assert!(result.is_none());
+    }
+}

--- a/tests/test_network.rs
+++ b/tests/test_network.rs
@@ -92,10 +92,10 @@ mod test_network {
                     address: "0x12e3582d7ca22234f39d2a7be12c98ea9c077e25"
                         .parse()
                         .unwrap(),
-                    topics: vec![Topic([
+                    topics: vec![[
                         239, 200, 244, 4, 28, 11, 164, 208, 151, 229, 75, 206, 126, 91, 196, 126,
                         197, 180, 92, 2, 112, 196, 35, 121, 196, 182, 145, 200, 89, 67, 237, 240,
-                    ])],
+                    ]],
                     data: Bytes::copy_from_slice(&clause_data[..]),
                 }],
                 transfers: vec![],


### PR DESCRIPTION
- Add public RLP
- Add HDNode docs
- Clean up address namespace
- Start adding http api support
- Use another unhex approach
- Get rid of another hex library
- Add network interface for blocks and transactions

TODO: add network support for account data retrieval and log access.
