### PR TITLE
fix address encode

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -36,8 +36,7 @@ impl Deref for Address {
 }
 impl Encodable for Address {
     fn encode(&self, out: &mut dyn open_fastrlp::BufMut) {
-        use crate::rlp::lstrip;
-        bytes::Bytes::copy_from_slice(&lstrip(self.0)).encode(out)
+        bytes::Bytes::copy_from_slice(self.0.as_bytes()).encode(out)
     }
 }
 impl Decodable for Address {


### PR DESCRIPTION
When trying to transfer a VIP180 token (for example, VTHO) I received the following error:
```
Failed to broadcast: raw: rlp: input string too short for thor.Address, decoding into (*tx.Transaction)(tx.body).Clauses[0](tx.clauseBody).To
```
It seems to me that the problem is in the serialization of the destination address.

Sample code of how I formed the transaction:
```
let clause = Clause {
    to: Some(Address::from_str("0x0000000000000000000000000000456E65726779").unwrap()), // VTHO token
    value: U256::zero(),
    data: transfer_data
}
let tx = TransactionBuilder::new(self.base_node.clone())
    .gas(gas)
    .add_clause(clause)
    .build()
    .await
    .unwrap();

// signing the transaction....

let txid = self.base_node.broadcast_transaction(&tx).await.unwrap(); // this is where the error occurs
```