### PR TITLE
Fix daily build failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ rand = { version = "^0.8", features = ["std", "std_rng"], optional = true }
 # version_sync: to ensure versions in `Cargo.toml` and `README.md` are in sync
 version-sync = "0.9.4"
 rand = { version = "0.8.5", features = ["getrandom"] }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "=1.38.1", features = ["full"] }
 bloomfilter = "^1.0"
 ethabi = "^18.0"
 
@@ -50,3 +50,6 @@ ethabi = "^18.0"
 serde = ["dep:serde", "dep:serde_json", "dep:serde_with"]
 http = ["dep:reqwest", "serde"]
 builder = ["http", "dep:rand"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }


### PR DESCRIPTION
Fails due to wrong dependency resolution - `tokio` rust-version constraint is ignored when resolving dependency version for some reason. https://stackoverflow.com/questions/78816757/how-to-prevent-cargo-from-resolving-transitive-dependencies-not-supporting-curre