### PR TITLE
deps: Switch to openrlp crate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
         run: cargo rdme --check
 
       - name: Run tests with coverage
-        run: RUST_BACKTRACE=1 cargo tarpaulin --out Xml --all-features
+        run: RUST_BACKTRACE=1 cargo tarpaulin --out Xml --all-features --doc --tests
 
       - name: Submit several transactions to chain
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,11 @@ jobs:
       - name: Stable with rustfmt and clippy
         uses: dtolnay/rust-toolchain@master
         with:
-          components: rustfmt, clippy
           toolchain: ${{matrix.rust}}
       - name: Release build
         run: cargo build --release --all-features
+      - name: Quick test
+        run: cargo test --all-features
 
   test:
     name: Test
@@ -45,10 +46,11 @@ jobs:
           persist-credentials: false
 
       - uses: actions/setup-python@v5
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: stable
+          toolchain: nightly
+          components: rustfmt, clippy
 
       - uses: pre-commit/action@v3.0.1
         env:
@@ -62,7 +64,7 @@ jobs:
         run: cargo rdme --check
 
       - name: Run tests with coverage
-        run: RUST_BACKTRACE=1 cargo tarpaulin --out Xml --all-features --doc --tests
+        run: RUST_BACKTRACE=1 cargo +nightly tarpaulin --out Xml --all-features --doc --tests
 
       - name: Submit several transactions to chain
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Possible header types:
 ## v0.1.0
 - Breaking: bumped MSRV to 1.78.0
 - Breaking: upgraded most of direct dependencies
+- Breaking: switched to `fastrlp` RLP implementation
+- Bugfix: doctests were skipped in CI
 
 ## v0.1.0-beta.4
 - Fixed incorrect address encoding in presence of leading zeroes (#28).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,26 +321,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,10 +398,8 @@ checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
 dependencies = [
  "crunchy",
  "fixed-hash",
- "impl-codec",
  "impl-rlp",
  "impl-serde",
- "scale-info",
  "tiny-keccak",
 ]
 
@@ -433,11 +411,9 @@ checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
 dependencies = [
  "ethbloom",
  "fixed-hash",
- "impl-codec",
  "impl-rlp",
  "impl-serde",
  "primitive-types",
- "scale-info",
  "uint",
 ]
 
@@ -446,6 +422,18 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+ "ethereum-types",
+]
 
 [[package]]
 name = "fixed-hash"
@@ -1133,18 +1121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "open-fastrlp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
- "ethereum-types",
-]
-
-[[package]]
 name = "openssl"
 version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,7 +1274,6 @@ dependencies = [
  "impl-codec",
  "impl-rlp",
  "impl-serde",
- "scale-info",
  "uint",
 ]
 
@@ -1608,30 +1583,6 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "scale-info"
-version = "2.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
-dependencies = [
- "cfg-if",
- "derive_more",
- "parity-scale-codec",
- "scale-info-derive",
-]
-
-[[package]]
-name = "scale-info-derive"
-version = "2.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "schannel"
@@ -1970,8 +1921,8 @@ dependencies = [
  "bytes",
  "ethabi",
  "ethereum-types",
+ "fastrlp",
  "itertools",
- "open-fastrlp",
  "rand 0.9.0",
  "reqwest",
  "rustc-hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [dependencies]
 bip32 = {version = "0.5", default-features = false, features = ["alloc", "secp256k1-ffi"]}
 blake2 = "0.10"
-bytes = "1.5"
+bytes = "1.10"
 ethereum-types = "0.14"
+fastrlp = {version = "0.3.1", features = ["ethereum-types", "std"]}
 itertools = "0.14"
-open-fastrlp = {version = "0.1", features = ["std", "ethereum-types"]}
 rand = {version = "^0.9", features = ["std", "std_rng"], optional = true}
 reqwest = {version = "0.12", features = ["json"], optional = true}
 rustc-hex = "2.1"
@@ -19,7 +19,7 @@ tiny-keccak = {version = "2.0", features = ["keccak"]}
 bloomfilter = "^3.0"
 ethabi = "^18.0"
 rand = "0.9.0"
-tokio = {version = "=1.38.1", features = ["full"]}
+tokio = {version = "1.38", features = ["full"]}
 # version_sync: to ensure versions in `Cargo.toml` and `README.md` are in sync
 version-sync = "0.9.4"
 

--- a/src/address.rs
+++ b/src/address.rs
@@ -35,7 +35,7 @@ impl Deref for Address {
     }
 }
 impl Encodable for Address {
-    fn encode(&self, out: &mut dyn open_fastrlp::BufMut) {
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
         self.0.encode(out)
     }
 }

--- a/src/hdnode.rs
+++ b/src/hdnode.rs
@@ -164,7 +164,6 @@ impl From<bip32::Error> for HDNodeError {
 /// ```rust
 /// use thor_devkit::hdnode::{Mnemonic, Language, HDNode};
 /// use rand::RngCore;
-/// use rand::rngs::OsRng;
 ///
 /// let mnemonic = Mnemonic::from_phrase(
 ///     "ignore empty bird silly journey junior ripple have guard waste between tenant",
@@ -174,7 +173,7 @@ impl From<bip32::Error> for HDNodeError {
 /// let wallet = HDNode::build().mnemonic(mnemonic).build().expect("Must be buildable");
 /// // OR
 /// let mut entropy = [0u8; 64];
-/// OsRng.fill_bytes(&mut entropy);
+/// rand::rng().fill_bytes(&mut entropy);
 /// let other_wallet = HDNode::build().seed(entropy).build().expect("Must be buildable");
 /// ```
 #[derive(Clone, Default)]

--- a/src/rlp.rs
+++ b/src/rlp.rs
@@ -264,6 +264,27 @@ macro_rules! rlp_encodable {
     }
 }
 
+macro_rules! map_to_option {
+    ($name:ident) => {
+        impl<T: Encodable + Decodable, S: Into<T>> From<Option<S>> for $name<T> {
+            fn from(value: Option<S>) -> Self {
+                match value {
+                    Some(v) => Self::Just(v.into()),
+                    None => Self::Nothing,
+                }
+            }
+        }
+        impl<T: Encodable + Decodable> From<$name<T>> for Option<T> {
+            fn from(value: $name<T>) -> Self {
+                match value {
+                    $name::Just(v) => Self::Some(v),
+                    $name::Nothing => Self::None,
+                }
+            }
+        }
+    };
+}
+
 /// Serialization wrapper for `Option` to serialize `None` as empty `Bytes`.
 ///
 /// <div class="warning">
@@ -276,27 +297,13 @@ pub enum AsBytes<T: Encodable + Decodable> {
     #[doc(hidden)]
     Nothing,
 }
+map_to_option!(AsBytes);
+
 impl<T: Encodable + Decodable> Encodable for AsBytes<T> {
     fn encode(&self, out: &mut dyn BufMut) {
         match self {
             Self::Just(value) => value.encode(out),
             Self::Nothing => Bytes::new().encode(out),
-        }
-    }
-}
-impl<T: Encodable + Decodable, S: Into<T>> From<Option<S>> for AsBytes<T> {
-    fn from(value: Option<S>) -> Self {
-        match value {
-            Some(v) => Self::Just(v.into()),
-            None => Self::Nothing,
-        }
-    }
-}
-impl<T: Encodable + Decodable> From<AsBytes<T>> for Option<T> {
-    fn from(value: AsBytes<T>) -> Self {
-        match value {
-            AsBytes::Just(v) => Self::Some(v),
-            AsBytes::Nothing => Self::None,
         }
     }
 }
@@ -313,6 +320,9 @@ impl<T: Encodable + Decodable> Decodable for AsBytes<T> {
 
 /// Serialization wrapper for `Option` to serialize `None` as empty `Vec`.
 ///
+/// Note that it will not be able to distinguish `None` and `Some(vec![])`
+/// as they map to the same encoded value.
+///
 /// <div class="warning">
 ///  Do not use it directly: it is only intended for use with `rlp_encodable!` macro.
 /// </div>
@@ -323,6 +333,8 @@ pub enum AsVec<T: Encodable + Decodable> {
     #[doc(hidden)]
     Nothing,
 }
+map_to_option!(AsVec);
+
 impl<T: Encodable + Decodable> Encodable for AsVec<T> {
     fn encode(&self, out: &mut dyn BufMut) {
         match self {
@@ -335,36 +347,13 @@ impl<T: Encodable + Decodable> Encodable for AsVec<T> {
         }
     }
 }
-impl<T: Encodable + Decodable, S: Into<T>> From<Option<S>> for AsVec<T> {
-    fn from(value: Option<S>) -> Self {
-        match value {
-            Some(v) => Self::Just(v.into()),
-            None => Self::Nothing,
-        }
-    }
-}
-impl<T: Encodable + Decodable> From<AsVec<T>> for Option<T> {
-    fn from(value: AsVec<T>) -> Self {
-        match value {
-            AsVec::Just(v) => Self::Some(v),
-            AsVec::Nothing => Self::None,
-        }
-    }
-}
 impl<T: Encodable + Decodable> Decodable for AsVec<T> {
     fn decode(buf: &mut &[u8]) -> RLPResult<Self> {
         if buf[0] == fastrlp::EMPTY_LIST_CODE {
             let header = fastrlp::Header::decode(buf)?;
-            if !header.list {
-                Err(RLPError::UnexpectedString)
-            } else if header.payload_length != 0 {
-                Err(RLPError::ListLengthMismatch {
-                    expected: 0,
-                    got: header.payload_length,
-                })
-            } else {
-                Ok(Self::Nothing)
-            }
+            debug_assert!(header.list);
+            debug_assert!(header.payload_length == 0);
+            Ok(Self::Nothing)
         } else {
             Ok(Self::Just(T::decode(buf)?))
         }
@@ -372,7 +361,7 @@ impl<T: Encodable + Decodable> Decodable for AsVec<T> {
 }
 
 /// Serialization wrapper for `Option` to serialize `None` as nothing (do not modify
-/// output stream). This must be a last field in struct.
+/// output stream). This must be the last field in the struct.
 ///
 /// <div class="warning">
 ///  Do not use it directly: it is only intended for use with `rlp_encodable!` macro.
@@ -384,6 +373,8 @@ pub enum Maybe<T: Encodable + Decodable> {
     #[doc(hidden)]
     Nothing,
 }
+map_to_option!(Maybe);
+
 impl<T: Encodable + Decodable> Encodable for Maybe<T> {
     fn encode(&self, out: &mut dyn BufMut) {
         match self {
@@ -398,22 +389,6 @@ impl<T: Encodable + Decodable> Decodable for Maybe<T> {
             Ok(Self::Nothing)
         } else {
             Ok(Self::Just(T::decode(buf)?))
-        }
-    }
-}
-impl<T: Encodable + Decodable, S: Into<T>> From<Option<S>> for Maybe<T> {
-    fn from(value: Option<S>) -> Self {
-        match value {
-            Some(v) => Self::Just(v.into()),
-            None => Self::Nothing,
-        }
-    }
-}
-impl<T: Encodable + Decodable> From<Maybe<T>> for Option<T> {
-    fn from(value: Maybe<T>) -> Self {
-        match value {
-            Maybe::Just(v) => Self::Some(v),
-            Maybe::Nothing => Self::None,
         }
     }
 }
@@ -447,4 +422,156 @@ pub(crate) fn static_left_pad<const N: usize>(data: &[u8]) -> RLPResult<[u8; N]>
     // SAFETY: length checked above
     unsafe { v.get_unchecked_mut(N - data.len()..) }.copy_from_slice(data);
     Ok(v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_left_pad() {
+        assert_eq!(
+            static_left_pad::<80>(&[1u8; 100]).unwrap_err(),
+            RLPError::Overflow
+        );
+        assert_eq!(static_left_pad::<10>(&[]).unwrap(), [0u8; 10]);
+        assert_eq!(
+            static_left_pad::<10>(&[0u8]).unwrap_err(),
+            RLPError::LeadingZero
+        );
+        assert_eq!(static_left_pad::<5>(&[1, 2, 3]).unwrap(), [0, 0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn test_asbytes() {
+        rlp_encodable! {
+            #[derive(Eq, PartialEq, Debug)]
+            struct Test {
+                foo: Option<u8> => AsBytes<u8>,
+            }
+        }
+        // Struct header prefix
+        let header = fastrlp::EMPTY_LIST_CODE + 1;
+
+        let empty = Test { foo: None };
+        let mut buf = vec![];
+        empty.encode(&mut buf);
+        assert_eq!(buf, [header, fastrlp::EMPTY_STRING_CODE]);
+        assert_eq!(Test::decode(&mut &buf[..]).unwrap(), empty);
+
+        let full = Test { foo: Some(7) };
+        let mut buf = vec![];
+        full.encode(&mut buf);
+        assert_eq!(buf, [header, 7]);
+        assert_eq!(Test::decode(&mut &buf[..]).unwrap(), full);
+
+        let buf = [header, fastrlp::EMPTY_LIST_CODE];
+        assert_eq!(
+            Test::decode(&mut &buf[..]).unwrap_err(),
+            RLPError::UnexpectedList
+        );
+    }
+
+    #[test]
+    fn test_asvec() {
+        rlp_encodable! {
+            #[derive(Eq, PartialEq, Debug)]
+            struct Test {
+                foo: Option<u8> => AsVec<u8>,
+            }
+        }
+        // Struct header prefix
+        let header = fastrlp::EMPTY_LIST_CODE + 1;
+
+        let empty = Test { foo: None };
+        let mut buf = vec![];
+        empty.encode(&mut buf);
+        assert_eq!(buf, [header, fastrlp::EMPTY_LIST_CODE]);
+        assert_eq!(Test::decode(&mut &buf[..]).unwrap(), empty);
+
+        let full = Test { foo: Some(7) };
+        let mut buf = vec![];
+        full.encode(&mut buf);
+        assert_eq!(buf, [header, 7]);
+        assert_eq!(Test::decode(&mut &buf[..]).unwrap(), full);
+
+        let buf = [header, fastrlp::EMPTY_LIST_CODE + 1, 0x01];
+        assert_eq!(
+            Test::decode(&mut &buf[..]).unwrap_err(),
+            RLPError::UnexpectedList
+        );
+        let buf = [header, fastrlp::EMPTY_STRING_CODE + 1, 0x01];
+        assert_eq!(
+            Test::decode(&mut &buf[..]).unwrap_err(),
+            RLPError::NonCanonicalSingleByte
+        );
+
+        // Quirk: [EMPTY_STRING] parses into the same zero as [0x00]
+        let buf = [fastrlp::EMPTY_STRING_CODE];
+        assert_eq!(u8::decode(&mut &buf[..]).unwrap(), 0);
+        let buf = [header, fastrlp::EMPTY_STRING_CODE];
+        assert_eq!(Test::decode(&mut &buf[..]).unwrap(), Test { foo: Some(0) });
+    }
+
+    #[test]
+    fn test_vec_asvec() {
+        rlp_encodable! {
+            #[derive(Eq, PartialEq, Debug)]
+            struct Test {
+                foo: Option<Vec<u32>> => AsVec<Vec<u32>>,
+            }
+        }
+        // Struct header prefix
+        let header = fastrlp::EMPTY_LIST_CODE + 1;
+
+        let empty = Test { foo: None };
+        let mut buf = vec![];
+        empty.encode(&mut buf);
+        assert_eq!(buf, [header, fastrlp::EMPTY_LIST_CODE]);
+        assert_eq!(Test::decode(&mut &buf[..]).unwrap(), empty);
+
+        let blank = Test { foo: Some(vec![]) };
+        let mut buf = vec![];
+        blank.encode(&mut buf);
+        assert_eq!(buf, [header, fastrlp::EMPTY_LIST_CODE]);
+        // But it doesn't round-trip - we get None in return.
+        // Both None and empty vec map to the same encoded value.
+        assert_eq!(Test::decode(&mut &buf[..]).unwrap(), empty);
+
+        let full = Test {
+            foo: Some(vec![0x01, 0x02]),
+        };
+        let mut buf = vec![];
+        full.encode(&mut buf);
+        assert_eq!(buf, [header + 2, fastrlp::EMPTY_LIST_CODE + 2, 0x01, 0x02]);
+        assert_eq!(Test::decode(&mut &buf[..]).unwrap(), full);
+
+        let buf = [header, fastrlp::EMPTY_STRING_CODE + 1, 0x01];
+        assert_eq!(
+            Test::decode(&mut &buf[..]).unwrap_err(),
+            RLPError::NonCanonicalSingleByte
+        );
+    }
+
+    #[test]
+    fn test_maybe() {
+        rlp_encodable! {
+            #[derive(Eq, PartialEq, Debug)]
+            struct Test {
+                foo: Option<u8> => Maybe<u8>,
+            }
+        }
+
+        let empty = Test { foo: None };
+        let mut buf = vec![];
+        empty.encode(&mut buf);
+        assert_eq!(buf, [fastrlp::EMPTY_LIST_CODE]);
+        assert_eq!(Test::decode(&mut &buf[..]).unwrap(), empty);
+
+        let full = Test { foo: Some(7) };
+        let mut buf = vec![];
+        full.encode(&mut buf);
+        assert_eq!(buf, [fastrlp::EMPTY_LIST_CODE + 1, 7]);
+        assert_eq!(Test::decode(&mut &buf[..]).unwrap(), full);
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,6 +24,7 @@ pub fn keccak<S: AsRef<[u8]>>(bytes: S) -> [u8; 32] {
 
 #[cfg(feature = "serde")]
 pub(crate) mod unhex {
+    use crate::rlp::RLPError;
     use crate::U256;
     use rustc_hex::{FromHex, ToHex};
     use serde::de::Error;
@@ -175,10 +176,10 @@ pub(crate) mod unhex {
 
     #[inline]
     #[cfg(not(tarpaulin_include))]
-    fn static_left_pad<const N: usize>(data: &[u8]) -> Result<[u8; N], open_fastrlp::DecodeError> {
+    fn static_left_pad<const N: usize>(data: &[u8]) -> Result<[u8; N], RLPError> {
         // Similar to RLP padding, but allows leading zero. Tested there.
         if data.len() > N {
-            return Err(open_fastrlp::DecodeError::Overflow);
+            return Err(RLPError::Overflow);
         }
 
         let mut v = [0; N];

--- a/tests/test_address.rs
+++ b/tests/test_address.rs
@@ -1,4 +1,4 @@
-use open_fastrlp::Encodable;
+use thor_devkit::rlp::Encodable;
 use thor_devkit::{Address, AddressConvertible, PublicKey};
 
 #[test]

--- a/tests/test_transactions.rs
+++ b/tests/test_transactions.rs
@@ -521,3 +521,23 @@ fn test_intrinsic_gas_2() {
     let mut buf = vec![];
     tx.encode(&mut buf); // Must not fail
 }
+
+#[test]
+fn test_roundtrip_unsigned() {
+    // Has dependsOn set
+    let orig = decode_hex("f85d4a880106f4db1482fd5a81b4e1e09477845a52acad7fe6a346f5b09e5e89e7caec8e3b890391c64cd2bc206c008080828ca0a0a7567ddfbbf4c8ace8a5aa23a4b852b98dd7ed1d4ff86df35e929a15f1c2541c88a63565b632b9b7c3c0");
+    let parsed = Transaction::decode(&mut &orig[..]).expect("Must parse");
+    let mut buf = vec![];
+    parsed.encode(&mut buf);
+    assert_eq!(buf, orig);
+}
+
+#[test]
+fn test_roundtrip_unsigned_no_depends_on() {
+    // Has dependsOn set to null
+    let orig = decode_hex("f83d4a880106f4db1482fd5a81b4e1e09477845a52acad7fe6a346f5b09e5e89e7caec8e3b890391c64cd2bc206c008080828ca08088a63565b632b9b7c3c0");
+    let parsed = Transaction::decode(&mut &orig[..]).expect("Must parse");
+    let mut buf = vec![];
+    parsed.encode(&mut buf);
+    assert_eq!(buf, orig);
+}


### PR DESCRIPTION
Only one quirk: `openrlp` serializes `Vec<u8>` as `Bytes`. That's arguably more consistent, and we only had one field to adjust