### PR TITLE
Replace dependabot with Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: cargo
-    directory: /
-    schedule:
-      interval: weekly

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:recommended"
+    ],
+    "lockFileMaintenance": {
+        "enabled": true
+    },
+    "packageRules": [
+        {
+            "groupName": "pre-commit",
+            "matchManagers": [
+                "pre-commit"
+            ]
+        }
+    ],
+    "pre-commit": {
+        "enabled": true
+    }
+}


### PR DESCRIPTION
Dependabot is unable to handle our dependencies reasonably well and does not support GHA and pre-commit